### PR TITLE
Allowing Insert or Update (Upsert) of a Record Using an External ID.

### DIFF
--- a/src/ForceToolkitForNET/ForceClient.cs
+++ b/src/ForceToolkitForNET/ForceClient.cs
@@ -79,6 +79,19 @@ namespace Salesforce.Force
             return response;
         }
 
+        public async Task<bool> UpsertExternalAsync(string objectName, string externalID, string recordId, object record)
+        {
+            if (string.IsNullOrEmpty(objectName)) throw new ArgumentNullException("objectName");
+            if (string.IsNullOrEmpty(externalID)) throw new ArgumentNullException("externalID");
+            if (string.IsNullOrEmpty(recordId)) throw new ArgumentNullException("recordId");
+            if (record == null) throw new ArgumentNullException("record");
+
+            //TODO: implement try/catch and throw auth exception if appropriate
+
+            var response = await _serviceHttpClient.HttpPatchAsync(record, string.Format("sobjects/{0}/{1}/{2}", objectName, externalID, recordId));
+            return response;
+        }
+
         public async Task<bool> DeleteAsync(string objectName, string recordId)
         {
             if (string.IsNullOrEmpty(objectName)) throw new ArgumentNullException("objectName");


### PR DESCRIPTION
This change adds the upsert functionality found in the api docs to the force client.
###### api docs on using Upsert

https://www.salesforce.com/us/developer/docs/api_rest/Content/dome_upsert.htm
###### caveats
- The unit tests created for this change assume that an external ID field, “ExternalID__c” has been added to Account. 
- I'm not sure about the name UpsertExternalAsync
