### PR TITLE
Added support for ApexRest API in ServiceHttpClient.

### DIFF
--- a/src/CommonLibrariesForNET/Common.cs
+++ b/src/CommonLibrariesForNET/Common.cs
@@ -7,13 +7,19 @@ namespace Salesforce.Common
 {
     public static class Common
     {
-        public static string FormatUrl(string resourceName, string instanceUrl, string apiVersion)
+        public static string FormatUrl(string resourceName, string instanceUrl, string apiVersion, ServiceType serviceType = ServiceType.Data)
         {
             if (string.IsNullOrEmpty(resourceName)) throw new ArgumentNullException("resourceName");
             if (string.IsNullOrEmpty(instanceUrl)) throw new ArgumentNullException("instanceUrl");
+
+            if (serviceType == ServiceType.ApexRest)
+            {
+                return string.Format("{0}/services/{1}/{2}", instanceUrl,  serviceType.ToString().ToLower(), resourceName);
+            }
+
             if (string.IsNullOrEmpty(apiVersion)) throw new ArgumentNullException("apiVersion");
-            
-            return string.Format("{0}/services/data/{1}/{2}", instanceUrl, apiVersion, resourceName);
+
+            return string.Format("{0}/services/{1}/{2}/{3}", instanceUrl, serviceType.ToString().ToLower(), apiVersion, resourceName);
         }
 
         public static string FormatAuthUrl(

--- a/src/CommonLibrariesForNET/CommonLibrariesForNET.csproj
+++ b/src/CommonLibrariesForNET/CommonLibrariesForNET.csproj
@@ -54,6 +54,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Models\ResponseTypes.cs" />
     <Compile Include="ServiceHttpClient.cs" />
+    <Compile Include="ServiceType.cs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Threading.Tasks">

--- a/src/CommonLibrariesForNET/ServiceHttpClient.cs
+++ b/src/CommonLibrariesForNET/ServiceHttpClient.cs
@@ -20,6 +20,13 @@ namespace Salesforce.Common
         private readonly string _apiVersion;
         private readonly string _accessToken;
         private static HttpClient _httpClient;
+        private readonly ServiceType _serviceType;
+
+        public ServiceHttpClient(string instanceUrl, string apiVersion, string accessToken, string userAgent, ServiceType serviceType, HttpClient httpClient)
+            : this(instanceUrl, apiVersion, accessToken, userAgent, httpClient)
+        {
+            _serviceType = serviceType;
+        }
 
         public ServiceHttpClient(string instanceUrl, string apiVersion, string accessToken, HttpClient httpClient)
             : this(instanceUrl, apiVersion, accessToken, _userAgent, httpClient)
@@ -33,6 +40,7 @@ namespace Salesforce.Common
             _accessToken = accessToken;
             _userAgent = userAgent;
             _httpClient = httpClient;
+            _serviceType = ServiceType.Data;
 
             _httpClient.DefaultRequestHeaders.UserAgent.ParseAdd(string.Concat(_userAgent, "/", _apiVersion));
         }
@@ -44,7 +52,7 @@ namespace Salesforce.Common
 
         public async Task<T> HttpGetAsync<T>(string urlSuffix)
         {
-            var url = Common.FormatUrl(urlSuffix, _instanceUrl, _apiVersion);
+            var url = Common.FormatUrl(urlSuffix, _instanceUrl, _apiVersion, _serviceType);
 
             var request = new HttpRequestMessage()
             {
@@ -127,7 +135,7 @@ namespace Salesforce.Common
 
         public async Task<T> HttpPostAsync<T>(object inputObject, string urlSuffix)
         {
-            var url = Common.FormatUrl(urlSuffix, _instanceUrl, _apiVersion);
+            var url = Common.FormatUrl(urlSuffix, _instanceUrl, _apiVersion, _serviceType);
 
             _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _accessToken);
             _httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
@@ -150,7 +158,7 @@ namespace Salesforce.Common
 
         public async Task<bool> HttpPatchAsync(object inputObject, string urlSuffix)
         {
-            var url = Common.FormatUrl(urlSuffix, _instanceUrl, _apiVersion);
+            var url = Common.FormatUrl(urlSuffix, _instanceUrl, _apiVersion, _serviceType);
 
             _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _accessToken);
             _httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
@@ -179,7 +187,7 @@ namespace Salesforce.Common
 
         public async Task<bool> HttpDeleteAsync(string urlSuffix)
         {
-            var url = Common.FormatUrl(urlSuffix, _instanceUrl, _apiVersion);
+            var url = Common.FormatUrl(urlSuffix, _instanceUrl, _apiVersion, _serviceType);
 
             _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _accessToken);
             _httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));

--- a/src/CommonLibrariesForNET/ServiceType.cs
+++ b/src/CommonLibrariesForNET/ServiceType.cs
@@ -1,0 +1,10 @@
+﻿//TODO: add license header
+
+namespace Salesforce.Common
+{
+    public enum ServiceType
+    {
+        Data,
+        ApexRest
+    }
+}


### PR DESCRIPTION
The ApexRest API has a different URL format than the standard rest API. To use Salesforce.Common when working with ApexRest I added in functionality to specify the ServiceType which controls the URL format. To prevent breaking current implementations the default service type is the standard "data" URL format. With the new functionality people looking to utilize ApexRest can build custom clients based on ServiceHTTPClient and specify the service type ApexRest when creating the ServiceHTTPClient object.
##### Example Usage with ServiceType ApexRest:

```
new ServiceHttpClient(auth.InstanceUrl, auth.ApiVersion, auth.AccessToken, userAgent, ServiceType.ApexRest, new HttpClient());
```
##### Example Usage without ServiceType (same as before):

```
new ServiceHttpClient(auth.InstanceUrl, auth.ApiVersion, auth.AccessToken, userAgent, new HttpClient());
```
##### Example Usage ServiceType Data (which is the default and doesn't need to be specified):

```
new ServiceHttpClient(auth.InstanceUrl, auth.ApiVersion, auth.AccessToken, userAgent, ServiceType.Data, new HttpClient());
```
##### ApexRest Docs:
- http://www.salesforce.com/us/developer/docs/apexcode/Content/apex_rest_code_sample_basic.htm
- http://wiki.developerforce.com/page/Creating_REST_APIs_using_Apex_REST
##### Notes:
- The tests added require setup of a ApexRest class using the salesforce docs example.
- New tests were added for FormatUrl method in Common
- I don't think adding functionality to the ForceClient makes sense but this change does allow people to create custom clients that specify the ApexRest Url format.
