### PR TITLE
Added NUnit 2.6.3 test runner.

### DIFF
--- a/src/ForceToolkitForNet.FunctionalTests/ForceClientTests.cs
+++ b/src/ForceToolkitForNet.FunctionalTests/ForceClientTests.cs
@@ -14,6 +14,7 @@ using Salesforce.Common;
 using Salesforce.Force.FunctionalTests.Models;
 //using WadeWegner.Salesforce.SOAPHelpers;
 //using WadeWegner.Salesforce.SOAPHelpers.Models;
+using System.Diagnostics;
 
 namespace Salesforce.Force.FunctionalTests
 {

--- a/src/ForceToolkitForNet.FunctionalTests/ForceToolkitForNet.FunctionalTests.csproj
+++ b/src/ForceToolkitForNet.FunctionalTests/ForceToolkitForNet.FunctionalTests.csproj
@@ -37,9 +37,6 @@
     <Reference Include="Newtonsoft.Json">
       <HintPath>..\packages\Newtonsoft.Json.6.0.1\lib\portable-net45+wp80+win8\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="nunit.framework">
-      <HintPath>..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
-    </Reference>
     <Reference Include="Salesforce.Common, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\DeveloperForce.Common.0.4.1\lib\Salesforce.Common.dll</HintPath>
@@ -54,14 +51,17 @@
       <HintPath>..\packages\Microsoft.Net.Http.2.2.18\lib\portable-net45+win8\System.Net.Http.Primitives.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http">
-       <HintPath>..\packages\Microsoft.Net.Http.2.2.18\lib\portable-net40+sl4+win8+wp71\System.Net.Http.dll</HintPath>
-      </Reference>
+      <HintPath>..\packages\Microsoft.Net.Http.2.2.18\lib\portable-net40+sl4+win8+wp71\System.Net.Http.dll</HintPath>
+    </Reference>
     <Reference Include="System.Net.Http.WebRequest" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
+    <Reference Include="nunit.framework">
+      <HintPath>..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ForceClientTests.cs" />

--- a/src/ForceToolkitForNet.UnitTests/ForceClientTests.cs
+++ b/src/ForceToolkitForNet.UnitTests/ForceClientTests.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Net.Http;
 using NUnit.Framework;
+using System.Threading.Tasks;
 
 namespace Salesforce.Force.UnitTests
 {
@@ -10,7 +11,7 @@ namespace Salesforce.Force.UnitTests
     public class ForceClientTests
     {
         [Test]
-        public async void Requests_CheckHttpRequestMessage_UserAgent()
+        public async Task Requests_CheckHttpRequestMessage_UserAgent()
         {
             var httpClient = new HttpClient(new ServiceClientRouteHandler(r => Assert.AreEqual(r.Headers.UserAgent.ToString(), "forcedotcom-toolkit-dotnet/v29")));
             var forceClient = new ForceClient("http://localhost:1899", "accessToken", "v29", httpClient);

--- a/src/ForceToolkitForNet.UnitTests/ForceToolkitForNet.UnitTests.csproj
+++ b/src/ForceToolkitForNet.UnitTests/ForceToolkitForNet.UnitTests.csproj
@@ -14,7 +14,7 @@
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
     <ProductVersion>12.0.0</ProductVersion>
-     <SchemaVersion>2.0</SchemaVersion>
+    <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -34,13 +34,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Newtonsoft.Json.6.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-    </Reference>
-    <Reference Include="nunit.framework">
-      <HintPath>..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
-    </Reference>
     <Reference Include="Salesforce.Common, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\DeveloperForce.Common.0.4.1\lib\Salesforce.Common.dll</HintPath>
@@ -48,9 +41,9 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Net" />
-        <Reference Include="System.Net.Http">
-       <HintPath>..\packages\Microsoft.Net.Http.2.2.18\lib\portable-net40+sl4+win8+wp71\System.Net.Http.dll</HintPath>
-      </Reference>
+    <Reference Include="System.Net.Http">
+      <HintPath>..\packages\Microsoft.Net.Http.2.2.18\lib\portable-net40+sl4+win8+wp71\System.Net.Http.dll</HintPath>
+    </Reference>
     <Reference Include="System.Net.Http.Extensions">
       <HintPath>..\packages\Microsoft.Net.Http.2.2.18\lib\portable-net45+win8\System.Net.Http.Extensions.dll</HintPath>
     </Reference>
@@ -62,6 +55,12 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>..\packages\Newtonsoft.Json.6.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="nunit.framework">
+      <HintPath>..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ForceClientTests.cs" />
@@ -74,7 +73,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ForceToolkitForNET\ForceToolkitForNET.csproj">
-      <Project>{1cc985bc-27f3-4f1d-8946-f4ddb084b58f}</Project>
+      <Project>{1CC985BC-27F3-4F1D-8946-F4DDB084B58F}</Project>
       <Name>ForceToolkitForNET</Name>
     </ProjectReference>
   </ItemGroup>

--- a/src/ForceToolkitForNet.UnitTests/packages.config
+++ b/src/ForceToolkitForNet.UnitTests/packages.config
@@ -6,4 +6,5 @@
   <package id="Microsoft.Net.Http" version="2.2.18" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.1" targetFramework="net45" />
   <package id="NUnit" version="2.6.3" targetFramework="net45" />
+  <package id="NUnit.Runners" version="2.6.3" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
nunit-console added async/await in version 2.6.3. Added the
runners nuget so that this version can be used to
execute the tests correctly.

To run:
`mono packages/NUnit.Runners.2.6.3/tools/nunit-console.exe -labels -noshadow ~/Source/Force.com-Toolkit-for-NET/src/ForceToolkitForNet.FunctionalTests/bin/Debug/Salesforce.Force.FunctionalTests.dll ~/Source/Force.com-Toolkit-for-NET/src/ForceToolkitForNet.UnitTests/bin/Debug/Salesforce.Force.UnitTests.dll ~/Source/Force.com-Toolkit-for-NET/src/CommonLibrariesForNET.UnitTests/bin/Debug/Salesforce.Common.UnitTests.dll ~/Source/Force.com-Toolkit-for-NET/src/CommonLibrariesForNET.FunctionalTests/bin/Debug/Salesforce.Common.FunctionalTests.dll`
