### PR TITLE
Add RefreshToken to the WebServer auth response

### DIFF
--- a/src/CommonLibrariesForNET/AuthenticationClient.cs
+++ b/src/CommonLibrariesForNET/AuthenticationClient.cs
@@ -13,6 +13,7 @@ namespace Salesforce.Common
     {
         public string InstanceUrl { get; set; }
         public string AccessToken { get; set; }
+        public string RefreshToken { get; set; }
         public string Id { get; set; }
         public string ApiVersion { get; set; }
         private const string UserAgent = "common-libraries-dotnet";
@@ -132,11 +133,12 @@ namespace Salesforce.Common
 
             if (responseMessage.IsSuccessStatusCode)
             {
-                var authToken = JsonConvert.DeserializeObject<AuthToken>(response);
+                var authToken = JsonConvert.DeserializeObject<AuthTokenWithRefresh>(response);
 
                 AccessToken = authToken.access_token;
                 InstanceUrl = authToken.instance_url;
                 Id = authToken.id;
+                RefreshToken = authToken.refresh_token;
             }
             else
             {

--- a/src/CommonLibrariesForNET/CommonLibrariesForNET.csproj
+++ b/src/CommonLibrariesForNET/CommonLibrariesForNET.csproj
@@ -39,6 +39,7 @@
   <ItemGroup>
     <Compile Include="AuthenticationClient.cs" />
     <Compile Include="Common.cs" />
+    <Compile Include="Models\AuthTokenWithRefresh.cs" />
     <Compile Include="Models\DescribeGlobalResult.cs" />
     <Compile Include="Models\DisplayTypes.cs" />
     <Compile Include="ForceAuthException.cs" />

--- a/src/CommonLibrariesForNET/Models/AuthTokenWithRefresh.cs
+++ b/src/CommonLibrariesForNET/Models/AuthTokenWithRefresh.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Salesforce.Common.Models
+{
+    public class AuthTokenWithRefresh : AuthToken
+    {
+        public string refresh_token;
+    }
+}


### PR DESCRIPTION
Implements the refresh_token for use in later token auth calls. Uses the same pattern as the existing object fields, so the client.RefreshToken field will be present but empty if you make a request that does not include 'refresh_token' in the initial call's scope
