### PR TITLE
Updated QueryAsync<T> to expose and accept nextRecordUrl to enabling query result sets greater than 2000 records

### DIFF
--- a/samples/SimpleConsole/App.config
+++ b/samples/SimpleConsole/App.config
@@ -4,10 +4,13 @@
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
     </startup>
   <appSettings>
-    <add key="SecurityToken" value=""/>
-    <add key="ConsumerKey" value=""/>
-    <add key="ConsumerSecret" value=""/>
-    <add key="Username" value=""/>
-    <add key="Password" value=""/>
+      <add key="SecurityToken" value="" />
+      <add key="ConsumerKey" value="" />
+      <add key="ConsumerSecret" value="" />
+      <add key="Username" value="" />
+      <add key="Password" value="" />
+
+      <!--set to true to point  SimpleConsole at a Sandbox environment-->
+      <add key="IsSandboxUser" value="false" /> 
   </appSettings>
 </configuration>

--- a/samples/SimpleConsole/SimpleConsole.csproj
+++ b/samples/SimpleConsole/SimpleConsole.csproj
@@ -51,11 +51,11 @@
     </Reference>
     <Reference Include="Salesforce.Common, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>packages\DeveloperForce.Common.0.4.2\lib\Salesforce.Common.dll</HintPath>
+      <HintPath>..\..\src\ForceToolkitForNET\bin\Debug\Salesforce.Common.dll</HintPath>
     </Reference>
     <Reference Include="Salesforce.Force, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>packages\DeveloperForce.Force.0.3.4\lib\Salesforce.Force.dll</HintPath>
+      <HintPath>..\..\src\ForceToolkitForNET\bin\Debug\Salesforce.Force.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -81,7 +81,9 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="App.config" />
+    <None Include="App.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="packages.config">
       <SubType>Designer</SubType>
     </None>

--- a/samples/SimpleConsole/packages.config
+++ b/samples/SimpleConsole/packages.config
@@ -1,7 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DeveloperForce.Common" version="0.4.2" targetFramework="net45" />
-  <package id="DeveloperForce.Force" version="0.3.4" targetFramework="net45" />
   <package id="Microsoft.Bcl" version="1.1.7" targetFramework="net45" />
   <package id="Microsoft.Bcl.Async" version="1.0.166" targetFramework="net45" />
   <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net45" />

--- a/src/CommonLibrariesForNET/Common.cs
+++ b/src/CommonLibrariesForNET/Common.cs
@@ -12,7 +12,13 @@ namespace Salesforce.Common
             if (string.IsNullOrEmpty(resourceName)) throw new ArgumentNullException("resourceName");
             if (string.IsNullOrEmpty(instanceUrl)) throw new ArgumentNullException("instanceUrl");
             if (string.IsNullOrEmpty(apiVersion)) throw new ArgumentNullException("apiVersion");
-            
+
+            //is query a nextRecordUrl request?
+            if (resourceName.StartsWith("/services/data", StringComparison.CurrentCultureIgnoreCase))
+            {
+                return string.Format("{0}{1}", instanceUrl, resourceName);
+            }
+
             return string.Format("{0}/services/data/{1}/{2}", instanceUrl, apiVersion, resourceName);
         }
 

--- a/src/CommonLibrariesForNET/Models/QueryResult.cs
+++ b/src/CommonLibrariesForNET/Models/QueryResult.cs
@@ -1,15 +1,17 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Collections.Generic;
 
 namespace Salesforce.Common.Models
 {
     public class QueryResult<T>
     {
+        /// <summary>
+        ///     Used to perform subsequent data requests if a query will return more than 2000 records
+        ///     If empty, then all data has been returned for the query
+        /// </summary>
+        public string nextRecordsUrl { get; set; }
+
         public int totalSize { get; set; }
         public string done { get; set; }
         public List<T> records { get; set; }
     }
-
 }

--- a/src/ForceToolkitForNET/ForceClient.cs
+++ b/src/ForceToolkitForNET/ForceClient.cs
@@ -36,10 +36,15 @@ namespace Salesforce.Force
         public async Task<QueryResult<T>> QueryAsync<T>(string query)
         {
             if (string.IsNullOrEmpty(query)) throw new ArgumentNullException("query");
-            
+
             //TODO: implement try/catch and throw auth exception if appropriate
 
-            var response = await _serviceHttpClient.HttpGetAsync<QueryResult<T>>(string.Format("query?q={0}", query));
+            //is query a nextRecordUrl request?
+            var request = query.StartsWith("/services/data", StringComparison.CurrentCultureIgnoreCase)
+                ? query
+                : string.Format("query?q={0}", query);
+
+            var response = await _serviceHttpClient.HttpGetAsync<QueryResult<T>>(request);
             return response;
         }
 

--- a/src/ForceToolkitForNET/ForceToolkitForNET.csproj
+++ b/src/ForceToolkitForNET/ForceToolkitForNET.csproj
@@ -51,7 +51,7 @@
       <HintPath>..\packages\Newtonsoft.Json.6.0.1\lib\portable-net45+wp80+win8\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="Salesforce.Common">
-      <HintPath>..\packages\DeveloperForce.Common.0.4.1\lib\Salesforce.Common.dll</HintPath>
+      <HintPath>..\CommonLibrariesForNET\bin\Debug\Salesforce.Common.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http">
       <HintPath>..\packages\Microsoft.Net.Http.2.2.18\lib\portable-net40+sl4+win8+wp71\System.Net.Http.dll</HintPath>

--- a/src/ForceToolkitForNET/packages.config
+++ b/src/ForceToolkitForNET/packages.config
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DeveloperForce.Common" version="0.4.1" targetFramework="portable-net45+wp80+win" />
   <package id="Microsoft.Bcl" version="1.1.6" targetFramework="portable-net45+wp80+win" />
   <package id="Microsoft.Bcl.Build" version="1.0.13" targetFramework="portable-net45+wp80+win" />
   <package id="Microsoft.Net.Http" version="2.2.18" targetFramework="portable-net45+wp80+win" />

--- a/src/ForceToolkitForNet.FunctionalTests/ForceToolkitForNet.FunctionalTests.csproj
+++ b/src/ForceToolkitForNet.FunctionalTests/ForceToolkitForNet.FunctionalTests.csproj
@@ -39,7 +39,7 @@
     </Reference>
     <Reference Include="Salesforce.Common, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\DeveloperForce.Common.0.4.1\lib\Salesforce.Common.dll</HintPath>
+      <HintPath>..\CommonLibrariesForNET\bin\Debug\Salesforce.Common.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/ForceToolkitForNet.FunctionalTests/packages.config
+++ b/src/ForceToolkitForNet.FunctionalTests/packages.config
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DeveloperForce.Common" version="0.4.1" targetFramework="net45" />
   <package id="Microsoft.Bcl" version="1.1.6" targetFramework="net45" />
   <package id="Microsoft.Bcl.Build" version="1.0.13" targetFramework="net45" />
   <package id="Microsoft.Net.Http" version="2.2.18" targetFramework="net45" />

--- a/src/ForceToolkitForNet.UnitTests/ForceToolkitForNet.UnitTests.csproj
+++ b/src/ForceToolkitForNet.UnitTests/ForceToolkitForNet.UnitTests.csproj
@@ -36,7 +36,7 @@
   <ItemGroup>
     <Reference Include="Salesforce.Common, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\DeveloperForce.Common.0.4.1\lib\Salesforce.Common.dll</HintPath>
+      <HintPath>..\CommonLibrariesForNET\bin\Debug\Salesforce.Common.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/ForceToolkitForNet.UnitTests/packages.config
+++ b/src/ForceToolkitForNet.UnitTests/packages.config
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DeveloperForce.Common" version="0.4.1" targetFramework="net45" />
   <package id="Microsoft.Bcl" version="1.1.6" targetFramework="net45" />
   <package id="Microsoft.Bcl.Build" version="1.0.13" targetFramework="net45" />
   <package id="Microsoft.Net.Http" version="2.2.18" targetFramework="net45" />


### PR DESCRIPTION
The current QueryAsync can only retrieve up to 2000 records because it does not expose or accept nextRecordUrl values. I made minor updates to enable exposing nextRecordUrl and passing it back into QueryAsync to complete a large result set request.

The additions to the SimpleConsole project demonstrate the change and also show how to hit a sandbox environment.
