### PR TITLE
Describe Layout calls

### DIFF
--- a/src/ForceToolkitForNET/ForceClient.cs
+++ b/src/ForceToolkitForNET/ForceClient.cs
@@ -133,6 +133,23 @@ namespace Salesforce.Force
 
             return _serviceHttpClient.HttpGetAsync<T>(string.Format("sobjects/{0}/describe/", objectName));
         }
+        
+        public Task<T> DescribeLayoutAsync<T>(string objectName)
+        {
+            if (string.IsNullOrEmpty(objectName)) throw new ArgumentNullException("objectName");
+            //TODO: implement try/catch and throw auth exception if appropriate
+            
+            return _serviceHttpClient.HttpGetAsync<T>(string.Format("sobjects/{0}/describe/layouts/", objectName));
+        }
+        
+        public Task<T> DescribeLayoutAsync<T>(string objectName, string recordTypeId)
+        {
+            if (string.IsNullOrEmpty(objectName)) throw new ArgumentNullException("objectName");
+            if (string.IsNullOrEmpty(recordTypeId)) throw new ArgumentNullException("recordTypeId");
+            //TODO: implement try/catch and throw auth exception if appropriate
+            
+            return _serviceHttpClient.HttpGetAsync<T>(string.Format("sobjects/{0}/describe/layouts/{1}", objectName, recordTypeId));
+        }
 
         public Task<T> RecentAsync<T>(int limit = 200)
         {

--- a/src/ForceToolkitForNET/IForceClient.cs
+++ b/src/ForceToolkitForNET/IForceClient.cs
@@ -16,6 +16,8 @@ namespace Salesforce.Force
         Task<DescribeGlobalResult<T>> GetObjectsAsync<T>();
         Task<T> BasicInformationAsync<T>(string objectName);
         Task<T> DescribeAsync<T>(string objectName);
+        Task<T> DescribeLayoutAsync<T>(string objectName);
+        Task<T> DescribeLayoutAsync<T>(string objectName, string recordTypeId);
         Task<T> RecentAsync<T>(int limit);
     }
 }


### PR DESCRIPTION
Adding a new method for accessing the describe layout of an object and
an overload allowing you to access the individual layouts given a record
type id. This would be very helpful for getting the picklists per record
type, but it seems like this hasn't been implemented by the Salesforce
team yet in their REST API.
