### PR TITLE
Support for nested entities in QueryByIdAsync<T>

### DIFF
--- a/src/CommonLibrariesForNET/Attributes/SubEntityAttribute.cs
+++ b/src/CommonLibrariesForNET/Attributes/SubEntityAttribute.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Salesforce.Common.Attributes
+{
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
+    public class SubEntityAttribute : Attribute
+    {
+    }
+}

--- a/src/CommonLibrariesForNET/CommonLibrariesForNET.csproj
+++ b/src/CommonLibrariesForNET/CommonLibrariesForNET.csproj
@@ -38,6 +38,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="Attributes\SubEntityAttribute.cs" />
     <Compile Include="AuthenticationClient.cs" />
     <Compile Include="Common.cs" />
     <Compile Include="Attributes\CreateableAttribute.cs" />

--- a/src/ForceToolkitForNET/ForceClient.cs
+++ b/src/ForceToolkitForNET/ForceClient.cs
@@ -2,7 +2,6 @@
 using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
-using System.Reflection;
 using Salesforce.Common;
 using Salesforce.Common.Models;
 
@@ -53,10 +52,7 @@ namespace Salesforce.Force
             if (string.IsNullOrEmpty(objectName)) throw new ArgumentNullException("objectName");
             if (string.IsNullOrEmpty(recordId)) throw new ArgumentNullException("recordId");
 
-            var fields = "";
-            fields = string.Join(", ", typeof(T).GetRuntimeProperties().Select(p => p.Name));
-
-            var query = string.Format("SELECT {0} FROM {1} WHERE Id = '{2}'", fields, objectName, recordId);
+            var query = ForceQueryBuilder.DeriveQuery<T>(objectName, recordId);
             var results = await QueryAsync<T>(query).ConfigureAwait(false);
 
             return results.records.FirstOrDefault();

--- a/src/ForceToolkitForNET/ForceQueryBuilder.cs
+++ b/src/ForceToolkitForNET/ForceQueryBuilder.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Salesforce.Common.Attributes;
+
+namespace Salesforce.Force
+{
+    public class ForceQueryBuilder
+    {
+        public static string DeriveQuery<T>(string objectName, string recordId)
+        {
+            var fieldNames = DeriveFieldsFromObject<T>();
+            var fields = string.Join(", ", fieldNames);
+
+            return string.Format("SELECT {0} FROM {1} WHERE Id = '{2}'", fields, objectName, recordId);
+        }
+
+        private static IEnumerable<string> DeriveFieldsFromObject<T>()
+        {
+            return DeriveFieldsFromObject(typeof(T));
+        }
+
+        private static IEnumerable<string> DeriveFieldsFromObject(Type propertyType, string prefix = "")
+        {
+            var allProperties = propertyType.GetRuntimeProperties();
+
+            var fieldNames = new List<string>();
+            foreach (var propertyInfo in allProperties)
+            {
+                if (propertyInfo.GetCustomAttribute<SubEntityAttribute>() != null)
+                {
+                    fieldNames.AddRange(DeriveFieldsFromObject(propertyInfo.PropertyType, propertyInfo.PropertyType.Name + "."));
+                    continue;
+                }
+                fieldNames.Add(string.Format("{0}{1}", prefix, propertyInfo.Name));
+            }
+
+            return fieldNames;
+        }
+    }
+}

--- a/src/ForceToolkitForNET/ForceToolkitForNET.csproj
+++ b/src/ForceToolkitForNET/ForceToolkitForNET.csproj
@@ -44,6 +44,7 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ForceQueryBuilder.cs" />
     <Compile Include="IForceClient.cs" />
     <Compile Include="ForceClient.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/ForceToolkitForNet.UnitTests/ForceQueryBuilderTests.cs
+++ b/src/ForceToolkitForNet.UnitTests/ForceQueryBuilderTests.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using NUnit.Framework;
+using Salesforce.Common.Attributes;
+
+namespace Salesforce.Force.UnitTests
+{
+    class Account
+    {
+        public string Name { get; set; }
+        public string Phone { get; set; }
+        public int CustomerNumber__c { get; set; }
+    }
+
+    class Opportunity
+    {
+        public string Name { get; set; }
+
+        [SubEntity]
+        public Account Account { get; set; }
+    }
+
+
+    [TestFixture]
+    public class ForceQueryBuilderTests
+    {
+        [Test]
+        public void SimpleObjectQueriesForAllProperties()
+        {
+            var query = ForceQueryBuilder.DeriveQuery<Account>("Account", "123");
+            Assert.AreEqual("SELECT Name, Phone, CustomerNumber__c FROM Account WHERE Id = '123'", query);
+        }
+
+        [Test]
+        public void QueryObjectWithNestedObject()
+        {
+            var query = ForceQueryBuilder.DeriveQuery<Opportunity>("Opportunity", "321");
+            Assert.AreEqual("SELECT Name, Account.Name, Account.Phone, Account.CustomerNumber__c FROM Opportunity WHERE Id = '321'", query);
+        }
+    }
+}

--- a/src/ForceToolkitForNet.UnitTests/ForceToolkitForNet.UnitTests.csproj
+++ b/src/ForceToolkitForNet.UnitTests/ForceToolkitForNet.UnitTests.csproj
@@ -73,6 +73,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ForceQueryBuilderTests.cs" />
     <Compile Include="Models\ObjectDescribeMetadata.cs" />
     <Compile Include="Models\ObjectFieldMetadata.cs" />
     <Compile Include="ForceClientTests.cs" />


### PR DESCRIPTION
Hi there,

I recently wanted to call `QueryByIdAsync` to grab opportunity details, although I also wanted a couple of Account level details, too.
I know I could have written the SOQL query myself and passed it directly into `QueryAsync` but I thought it was cleaner (from the consumer's perspective) to allow nesting entities.

See the `ForceQueryBuilderTests` for a super simple example.

Not sure if this is something you would be interested in? I thought it only polite to submit the PR either way =)
