### PR TITLE
Add InvalidSessionId Error code

### DIFF
--- a/src/CommonLibrariesForNET/Models/Error.cs
+++ b/src/CommonLibrariesForNET/Models/Error.cs
@@ -19,7 +19,8 @@
         StringTooLong,
         EntityIsDeleted,
         MalFormedId,
-        InvalidQueryFilterOperator
+        InvalidQueryFilterOperator,
+        InvalidSessionId
     }
     
 }


### PR DESCRIPTION
Added InvalidSessionId to identify a ForceException caused by an expired
token.

Used within my ForceClient wrapper to re-authenticate and retry when the
token expires.  Wrapper could be pushed but requires taking a reference
on Endjin.Retry nuget package.