### PR TITLE
Extending the functionality of the Chatter API wrapper by adding two …

### DIFF
--- a/src/ChatterToolkitForNET.FunctionalTests/ChatterClientTests.cs
+++ b/src/ChatterToolkitForNET.FunctionalTests/ChatterClientTests.cs
@@ -26,7 +26,7 @@ namespace Salesforce.Chatter.FunctionalTests
             _auth = new AuthenticationClient();
             _auth.UsernamePasswordAsync(ConsumerKey, ConsumerSecret, Username, Password, TokenRequestEndpointUrl).Wait();
 
-            const string apiVersion = "v30.0";
+            const string apiVersion = "v32.0";
             _chatterClient = new ChatterClient(_auth.InstanceUrl, _auth.AccessToken, apiVersion);
         }
 

--- a/src/ChatterToolkitForNET/ChatterClient.cs
+++ b/src/ChatterToolkitForNET/ChatterClient.cs
@@ -80,7 +80,7 @@ namespace Salesforce.Chatter
 
         public Task<T> GetGroupFeedAsync<T>(string groupId)
         {
-            return _serviceHttpClient.HttpGetAsync<T>(string.Format("chatter/feeds/record/{0}/feed-items", groupId));
+            return _serviceHttpClient.HttpGetAsync<T>(string.Format("chatter/feeds/record/{0}/feed-elements", groupId));
         }
 
         public Task<T> GetUsersAsync<T>()

--- a/src/ChatterToolkitForNET/ChatterClient.cs
+++ b/src/ChatterToolkitForNET/ChatterClient.cs
@@ -32,7 +32,7 @@ namespace Salesforce.Chatter
 
         public Task<T> PostFeedItemAsync<T>(FeedItemInput feedItemInput, string userId)
         {
-            return _serviceHttpClient.HttpPostAsync<T>(feedItemInput, string.Format("chatter/feeds/news/{0}/feed-elements", userId));
+            return _serviceHttpClient.HttpPostAsync<T>(feedItemInput, string.Format("chatter/feed-elements/{0}/capabilities/comments/items", userId));
         }
 
         public Task<T> PostFeedItemToObjectAsync<T>(ObjectFeedItemInput envelope)
@@ -48,19 +48,19 @@ namespace Salesforce.Chatter
 
         public Task<T> PostFeedItemCommentAsync<T>(FeedItemInput envelope, string feedId)
         {
-            return _serviceHttpClient.HttpPostAsync<T>(envelope, string.Format("chatter/feed-elements/{0}/comments", feedId));
+            return _serviceHttpClient.HttpPostAsync<T>(envelope, string.Format("chatter/feed-elements/{0}/capabilities/comments/items", feedId));
         }
 
         public Task<T> LikeFeedItemAsync<T>(string feedId)
         {
-            return _serviceHttpClient.HttpPostAsync<T>(null, string.Format("chatter/feed-elements/{0}/likes", feedId));
+            return _serviceHttpClient.HttpPostAsync<T>(null, string.Format("chatter/feed-elements/{0}/capabilities/chatter-likes/items", feedId));
         }
 
         public Task<T> ShareFeedItemAsync<T>(string feedId, string userId)
         {
-            var sharedFeedItem = new SharedFeedItemInput { OriginalFeedItemId = feedId };
+            var sharedFeedItem = new SharedFeedItemInput { OriginalFeedItemId = feedId, UserID = userId };
 
-            return _serviceHttpClient.HttpPostAsync<T>(sharedFeedItem, string.Format("chatter/feeds/user-profile/{0}/feed-elements", userId));
+            return _serviceHttpClient.HttpPostAsync<T>(sharedFeedItem, string.Format("chatter/feed-elements", userId));
         }
 
         public Task<T> GetMyNewsFeedAsync<T>(string query = "")

--- a/src/ChatterToolkitForNET/ChatterClient.cs
+++ b/src/ChatterToolkitForNET/ChatterClient.cs
@@ -35,12 +35,12 @@ namespace Salesforce.Chatter
             return _serviceHttpClient.HttpPostAsync<T>(feedItemInput, string.Format("chatter/feeds/news/{0}/feed-items", userId));
         }
 
-        public Task<T> PostFeedItemToObjectAsync<T>(FeedItemInput envelope)
+        public Task<T> PostFeedItemToObjectAsync<T>(ObjectFeedItemInput envelope)
         {
             return _serviceHttpClient.HttpPostAsync<T>(envelope, "chatter/feed-elements/");
         }
 
-        public Task<T> PostFeedItemWithAttachmentAsync<T>(FeedItemInput envelope, byte[] fileContents, string fileName)
+        public Task<T> PostFeedItemWithAttachmentAsync<T>(ObjectFeedItemInput envelope, byte[] fileContents, string fileName)
         {
             return _serviceHttpClient.HttpBinaryDataPostAsync<T>("chatter/feed-elements/", envelope, fileContents, "feedElementFileUpload", fileName);
         }

--- a/src/ChatterToolkitForNET/ChatterClient.cs
+++ b/src/ChatterToolkitForNET/ChatterClient.cs
@@ -10,8 +10,8 @@ namespace Salesforce.Chatter
     {
         private ServiceHttpClient _serviceHttpClient;
 
-        public ChatterClient(string instanceUrl, string accessToken, string apiVersion) 
-            : this (instanceUrl, accessToken, apiVersion, new HttpClient())
+        public ChatterClient(string instanceUrl, string accessToken, string apiVersion)
+            : this(instanceUrl, accessToken, apiVersion, new HttpClient())
         {
         }
 
@@ -19,7 +19,7 @@ namespace Salesforce.Chatter
         {
             _serviceHttpClient = new ServiceHttpClient(instanceUrl, apiVersion, accessToken, httpClient);
         }
-        
+
         public Task<T> FeedsAsync<T>()
         {
             return _serviceHttpClient.HttpGetAsync<T>("chatter/feeds");
@@ -35,6 +35,17 @@ namespace Salesforce.Chatter
             return _serviceHttpClient.HttpPostAsync<T>(feedItemInput, string.Format("chatter/feeds/news/{0}/feed-items", userId));
         }
 
+        public Task<T> PostFeedItemToObjectAsync<T>(FeedItemInput envelope)
+        {
+            return _serviceHttpClient.HttpPostAsync<T>(envelope, "chatter/feed-elements/");
+        }
+
+        public Task<T> PostFeedItemWithAttachmentAsync<T>(FeedItemInput envelope, byte[] fileContents, string fileName)
+        {
+            return _serviceHttpClient.HttpBinaryDataPostAsync<T>("chatter/feed-elements/", envelope, fileContents, "feedElementFileUpload", fileName);
+        }
+
+
         public Task<T> PostFeedItemCommentAsync<T>(FeedItemInput envelope, string feedId)
         {
             return _serviceHttpClient.HttpPostAsync<T>(envelope, string.Format("chatter/feed-items/{0}/comments", feedId));
@@ -47,7 +58,7 @@ namespace Salesforce.Chatter
 
         public Task<T> ShareFeedItemAsync<T>(string feedId, string userId)
         {
-            var sharedFeedItem = new SharedFeedItemInput {OriginalFeedItemId = feedId};
+            var sharedFeedItem = new SharedFeedItemInput { OriginalFeedItemId = feedId };
 
             return _serviceHttpClient.HttpPostAsync<T>(sharedFeedItem, string.Format("chatter/feeds/user-profile/{0}/feed-items", userId));
         }
@@ -57,7 +68,7 @@ namespace Salesforce.Chatter
             var url = "chatter/feeds/news/me/feed-items";
 
             if (!string.IsNullOrEmpty(query))
-                url += string.Format("?q={0}",query);
+                url += string.Format("?q={0}", query);
 
             return _serviceHttpClient.HttpGetAsync<T>(url);
         }

--- a/src/ChatterToolkitForNET/ChatterClient.cs
+++ b/src/ChatterToolkitForNET/ChatterClient.cs
@@ -32,7 +32,7 @@ namespace Salesforce.Chatter
 
         public Task<T> PostFeedItemAsync<T>(FeedItemInput feedItemInput, string userId)
         {
-            return _serviceHttpClient.HttpPostAsync<T>(feedItemInput, string.Format("chatter/feeds/news/{0}/feed-items", userId));
+            return _serviceHttpClient.HttpPostAsync<T>(feedItemInput, string.Format("chatter/feeds/news/{0}/feed-elements", userId));
         }
 
         public Task<T> PostFeedItemToObjectAsync<T>(ObjectFeedItemInput envelope)
@@ -48,24 +48,24 @@ namespace Salesforce.Chatter
 
         public Task<T> PostFeedItemCommentAsync<T>(FeedItemInput envelope, string feedId)
         {
-            return _serviceHttpClient.HttpPostAsync<T>(envelope, string.Format("chatter/feed-items/{0}/comments", feedId));
+            return _serviceHttpClient.HttpPostAsync<T>(envelope, string.Format("chatter/feed-elements/{0}/comments", feedId));
         }
 
         public Task<T> LikeFeedItemAsync<T>(string feedId)
         {
-            return _serviceHttpClient.HttpPostAsync<T>(null, string.Format("chatter/feed-items/{0}/likes", feedId));
+            return _serviceHttpClient.HttpPostAsync<T>(null, string.Format("chatter/feed-elements/{0}/likes", feedId));
         }
 
         public Task<T> ShareFeedItemAsync<T>(string feedId, string userId)
         {
             var sharedFeedItem = new SharedFeedItemInput { OriginalFeedItemId = feedId };
 
-            return _serviceHttpClient.HttpPostAsync<T>(sharedFeedItem, string.Format("chatter/feeds/user-profile/{0}/feed-items", userId));
+            return _serviceHttpClient.HttpPostAsync<T>(sharedFeedItem, string.Format("chatter/feeds/user-profile/{0}/feed-elements", userId));
         }
 
         public Task<T> GetMyNewsFeedAsync<T>(string query = "")
         {
-            var url = "chatter/feeds/news/me/feed-items";
+            var url = "chatter/feeds/news/me/feed-elements";
 
             if (!string.IsNullOrEmpty(query))
                 url += string.Format("?q={0}", query);

--- a/src/ChatterToolkitForNET/ChatterToolkitForNET.csproj
+++ b/src/ChatterToolkitForNET/ChatterToolkitForNET.csproj
@@ -39,6 +39,8 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ChatterClient.cs" />
+    <Compile Include="Models\Capabilities.cs" />
+    <Compile Include="Models\Content.cs" />
     <Compile Include="Models\GroupDetail.cs" />
     <Compile Include="IChatterClient.cs" />
     <Compile Include="Models\Address.cs" />

--- a/src/ChatterToolkitForNET/Models/Capabilities.cs
+++ b/src/ChatterToolkitForNET/Models/Capabilities.cs
@@ -1,0 +1,10 @@
+﻿using Newtonsoft.Json;
+
+namespace Salesforce.Chatter.Models
+{
+    public class Capabilities
+    {
+        [JsonProperty(PropertyName = "content")]
+        public Content Content { get; set; }
+    }
+}

--- a/src/ChatterToolkitForNET/Models/Content.cs
+++ b/src/ChatterToolkitForNET/Models/Content.cs
@@ -1,0 +1,13 @@
+﻿using Newtonsoft.Json;
+
+namespace Salesforce.Chatter.Models
+{
+    public class Content
+    {
+        [JsonProperty(PropertyName = "description")]
+        public string  Description { get; set; }
+
+        [JsonProperty(PropertyName = "title")]
+        public string Title { get; set; }
+    }
+}

--- a/src/ChatterToolkitForNET/Models/FeedItemInput.cs
+++ b/src/ChatterToolkitForNET/Models/FeedItemInput.cs
@@ -10,6 +10,13 @@ namespace Salesforce.Chatter.Models
         [JsonProperty(PropertyName = "body")]
         public MessageBodyInput Body { get; set; }
 
+
+    }
+
+    public class ObjectFeedItemInput : FeedItemInput
+    {
+        
+
         [JsonProperty(PropertyName = "feedElementType")]
         readonly public string FeedItem = "FeedItem";
 

--- a/src/ChatterToolkitForNET/Models/FeedItemInput.cs
+++ b/src/ChatterToolkitForNET/Models/FeedItemInput.cs
@@ -9,5 +9,15 @@ namespace Salesforce.Chatter.Models
 
         [JsonProperty(PropertyName = "body")]
         public MessageBodyInput Body { get; set; }
+
+        [JsonProperty(PropertyName = "feedElementType")]
+        readonly public string FeedItem = "FeedItem";
+
+        [JsonProperty(PropertyName = "subjectId")]
+        public string ObjectID { get; set; }
+
+        [JsonProperty(PropertyName = "capabilities")]
+        public Capabilities Capabilities { get; set; }
+
     }
 }

--- a/src/ChatterToolkitForNET/Models/GroupDetail.cs
+++ b/src/ChatterToolkitForNET/Models/GroupDetail.cs
@@ -18,7 +18,7 @@ namespace Salesforce.Chatter.Models
         public string EmailToChatterAddress { get; set; }
 
         [JsonProperty(PropertyName = "fileCount")]
-        public int FileCount { get; set; }
+        public int? FileCount { get; set; }
 
         [JsonProperty(PropertyName = "id")]
         public string Id { get; set; }

--- a/src/ChatterToolkitForNET/Models/SharedFeedItemInput.cs
+++ b/src/ChatterToolkitForNET/Models/SharedFeedItemInput.cs
@@ -10,5 +10,8 @@ namespace Salesforce.Chatter.Models
     {
         [JsonProperty(PropertyName = "originalFeedItemId")]
         public string OriginalFeedItemId { get; set; }
+
+        [JsonProperty(PropertyName = "userId")]
+        public string UserID { get; set; }
     }
 }

--- a/src/CommonLibrariesForNET/ServiceHttpClient.cs
+++ b/src/CommonLibrariesForNET/ServiceHttpClient.cs
@@ -73,7 +73,7 @@ namespace Salesforce.Common
             throw new ForceException(errorResponse[0].ErrorCode, errorResponse[0].Message);
         }
 
-		/// <summary>
+        /// <summary>
         /// Call a custom REST API
         /// </summary>
         /// <typeparam name="T"></typeparam>
@@ -86,8 +86,8 @@ namespace Salesforce.Common
 
             return await HttpGetAsync<T>(url);
         }
-        
-		public async Task<IList<T>> HttpGetAsync<T>(string urlSuffix, string nodeName)
+
+        public async Task<IList<T>> HttpGetAsync<T>(string urlSuffix, string nodeName)
         {
             string next = null;
             string response = null;
@@ -221,8 +221,10 @@ namespace Salesforce.Common
 
             var responseMessage = await _httpClient.SendAsync(request).ConfigureAwait(false);
 
-            if (responseMessage.IsSuccessStatusCode) {
-                if (responseMessage.StatusCode != System.Net.HttpStatusCode.NoContent) {
+            if (responseMessage.IsSuccessStatusCode)
+            {
+                if (responseMessage.StatusCode != System.Net.HttpStatusCode.NoContent)
+                {
                     var response = await responseMessage.Content.ReadAsStringAsync().ConfigureAwait(false);
 
                     var r = JsonConvert.DeserializeObject<SuccessResponse>(response);
@@ -259,6 +261,53 @@ namespace Salesforce.Common
 
             var errorResponse = JsonConvert.DeserializeObject<ErrorResponses>(response);
             throw new ForceException(errorResponse[0].ErrorCode, errorResponse[0].Message);
+        }
+
+        public async Task<T> HttpBinaryDataPostAsync<T>(string urlSuffix, object inputObject, byte[] fileContents, string headerName, string fileName)
+        {
+            var url = Common.FormatUrl(urlSuffix, _instanceUrl, _apiVersion);
+
+            var request = new HttpRequestMessage
+            {
+                RequestUri = new Uri(url),
+                Method = HttpMethod.Post,
+
+            };
+
+            var json = JsonConvert.SerializeObject(inputObject,
+                Formatting.None,
+                new JsonSerializerSettings
+                {
+                    NullValueHandling = NullValueHandling.Ignore,
+                });
+
+
+
+            MultipartFormDataContent content = new MultipartFormDataContent();
+
+            var stringContent = new StringContent(json, Encoding.UTF8, "application/json");
+            stringContent.Headers.Add("Content-Disposition", "form-data; name=\"json\"");
+            content.Add(stringContent);
+
+
+            ByteArrayContent byteArrayContent = new ByteArrayContent(fileContents);
+            byteArrayContent.Headers.Add("Content-Type", "application/octet-stream");
+            byteArrayContent.Headers.Add("Content-Disposition", String.Format("form-data; name=\"{0}\"; filename=\"{1}\"", headerName, fileName));
+            content.Add(byteArrayContent, headerName, fileName);
+
+            var responseMessage = await _httpClient.PostAsync(new Uri(url), content).ConfigureAwait(false);
+            var response = await responseMessage.Content.ReadAsStringAsync().ConfigureAwait(false);
+
+            if (responseMessage.IsSuccessStatusCode)
+            {
+                var r = JsonConvert.DeserializeObject<T>(response);
+                return r;
+            }
+
+            var errorResponse = JsonConvert.DeserializeObject<ErrorResponses>(response);
+            throw new ForceException(errorResponse[0].ErrorCode, errorResponse[0].Message);
+
+
         }
     }
 }

--- a/src/CommonLibrariesForNET/ServiceHttpClient.cs
+++ b/src/CommonLibrariesForNET/ServiceHttpClient.cs
@@ -307,7 +307,6 @@ namespace Salesforce.Common
             var errorResponse = JsonConvert.DeserializeObject<ErrorResponses>(response);
             throw new ForceException(errorResponse[0].ErrorCode, errorResponse[0].Message);
 
-
         }
     }
 }


### PR DESCRIPTION
…new methods:

- The ability to post directly to a particular object (such as opportunity or account) rather than to news or me. This is accomplished through the PostFeedItemToObjectAsync method.

- The ability to post a file to a particular object with Chatter, by passing the byte array of the file contents as well as some content for it. This is accomplished through the PostFeedItemWithAttachmentAsync method.

Adds a few classes to extend the property requirements of FeedItem, such as Capabilities and Content.

I'm also adding an extra method to the HTTPservice implementation, which allows for binary data to be sent alongside a JSON payload when uploading files.