### PR TITLE
Fix refresh token OAuth flow

### DIFF
--- a/src/CommonLibrariesForNET/Common.cs
+++ b/src/CommonLibrariesForNET/Common.cs
@@ -82,7 +82,7 @@ namespace Salesforce.Common
 
             var url =
             string.Format(
-                "{0}?grant_type=RefreshToken&client_id={1}{2}&RefreshToken={3}",
+                "{0}?grant_type=refresh_token&client_id={1}{2}&refresh_token={3}",
                 tokenRefreshUrl,
                 clientId,
                 clientSecretQuerystring,


### PR DESCRIPTION
[This commit](https://github.com/developerforce/Force.com-Toolkit-for-NET/commit/8ff9da7c3e686a376498298e2aab5435caa6d9a0#diff-77df78017e679b14a9fd361511893402L85) changed both `refresh_token` strings to `RefreshToken` in `FormatRefreshTokenUrl` as part of a large batch of changes to match C# naming conventions. I think this was an accidental change.

With `RefreshToken` I got `UnsupportedGrantType` exceptions when I attempted the refresh token flow, and changing it to `refresh_token` made it work normally. [The Salesforce docs also show `refresh_token`.](https://help.salesforce.com/apex/HTViewHelpDoc?id=remoteaccess_oauth_refresh_token_flow.htm&language=en_US)