### PR TITLE
Add correct refresh token header

### DIFF
--- a/src/CommonLibrariesForNET/AuthenticationClient.cs
+++ b/src/CommonLibrariesForNET/AuthenticationClient.cs
@@ -62,7 +62,9 @@ namespace Salesforce.Common
 				Content = content
             };
 
-			request.Headers.UserAgent.ParseAdd(string.Concat(UserAgent, "/", ApiVersion));
+	    request.Headers.UserAgent.ParseAdd(string.Concat(UserAgent, "/", ApiVersion));
+	    request.Content = new StringContent("");
+            request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/x-www-form-urlencode");
 
             var responseMessage = await _httpClient.SendAsync(request).ConfigureAwait(false);
             var response = await responseMessage.Content.ReadAsStringAsync().ConfigureAwait(false);


### PR DESCRIPTION
I was getting invalid grant errors and was finding the the header for refresh tokens was being set to application/json when it actually needs to be application/x-www-form-urlencode.