### PR TITLE
Support for DataMember attributes

### DIFF
--- a/src/ForceToolkitForNET/ForceClient.cs
+++ b/src/ForceToolkitForNET/ForceClient.cs
@@ -63,7 +63,12 @@ namespace Salesforce.Force
             if (string.IsNullOrEmpty(recordId)) throw new ArgumentNullException("recordId");
 
             var fields = "";
-            fields = string.Join(", ", typeof(T).GetRuntimeProperties().Select(p => p.Name));
+            //fields = string.Join(", ", typeof(T).GetRuntimeProperties().Select(p => p.Name));
+            fields = string.Join(", ", typeof(T).GetRuntimeProperties()
+                .Select(p => { 
+                    var customAttribute = p.GetCustomAttribute<DataMemberAttribute>();
+                    return (customAttribute == null || customAttribute.Name == null) ? p.Name : customAttribute.Name;
+                }));
 
             var query = string.Format("SELECT {0} FROM {1} WHERE Id = '{2}'", fields, objectName, recordId);
             var results = await QueryAsync<T>(query).ConfigureAwait(false);


### PR DESCRIPTION
In our project, we use DataMember attributes so that we don't need to deal with the __c ugliness of custom fields. The field name will be whatever we want and the datamember attribute will reflect the salesforce API name. The toolkit doesn't play well with this, since it is reflecting on the property names alone. The proposed code tries to handle this by looking for the datamember attribute first. If it is not available, it will pick up the property name.