### PR TITLE
Fixed Sfdc Api being unable to deserialize default date format

### DIFF
--- a/src/CommonLibrariesForNET/ServiceHttpClient.cs
+++ b/src/CommonLibrariesForNET/ServiceHttpClient.cs
@@ -159,7 +159,8 @@ namespace Salesforce.Common
                 new JsonSerializerSettings
                 {
                     NullValueHandling = NullValueHandling.Ignore,
-                    ContractResolver = new CreateableContractResolver()
+                    ContractResolver = new CreateableContractResolver(),
+                    DateFormatString = "yyyy-MM-ddThh:mm:ssZzzz"
                 });
 
             var content = new StringContent(json, Encoding.UTF8, "application/json");
@@ -184,6 +185,8 @@ namespace Salesforce.Common
                 new JsonSerializerSettings
                 {
                     NullValueHandling = NullValueHandling.Ignore,
+                    ContractResolver = new CreateableContractResolver(),
+                    DateFormatString = "yyyy-MM-ddThh:mm:ssZzzz"
                 });
 
             var content = new StringContent(json, Encoding.UTF8, "application/json");
@@ -214,7 +217,8 @@ namespace Salesforce.Common
                 Formatting.None,
                 new JsonSerializerSettings
                 {
-                    ContractResolver = new UpdateableContractResolver()
+                    ContractResolver = new UpdateableContractResolver(),
+                    DateFormatString = "yyyy-MM-ddThh:mm:ssZzzz"
                 });
 
             request.Content = new StringContent(json, Encoding.UTF8, "application/json");


### PR DESCRIPTION
Sfdc responds with the error message `Salesforce.Common.ForceException: Cannot deserialize instance of date from VALUE_STRING value 2015-07-23T09:38:33.6366008+02:00 at [line:1, column:268]` when posting a sObject containing a `DateTime`.

This PR overrides Newtonsoft.JSONs default serialization `DateTime` format.

I'm not sure about my addition in line 188. The missing `CreateableContractResolver()` call might be intended, but it looks like someone forgot to add the line there.