### PR TITLE
Fixed Sfdc Api being unable to deserialize default date format

### DIFF
--- a/src/CommonLibrariesForNET/ServiceHttpClient.cs
+++ b/src/CommonLibrariesForNET/ServiceHttpClient.cs
@@ -186,6 +186,7 @@ namespace Salesforce.Common
                 new JsonSerializerSettings
                 {
                     NullValueHandling = NullValueHandling.Ignore,
+                    ContractResolver = new CreateableContractResolver(),
                     DateFormatString = DateFormat
                 });
 

--- a/src/CommonLibrariesForNET/ServiceHttpClient.cs
+++ b/src/CommonLibrariesForNET/ServiceHttpClient.cs
@@ -15,6 +15,7 @@ namespace Salesforce.Common
     public class ServiceHttpClient : IServiceHttpClient, IDisposable
     {
         private const string UserAgent = "forcedotcom-toolkit-dotnet";
+        private const string DateFormat = "s";
         private readonly string _instanceUrl;
         private readonly string _apiVersion;
         private readonly HttpClient _httpClient;
@@ -159,7 +160,8 @@ namespace Salesforce.Common
                 new JsonSerializerSettings
                 {
                     NullValueHandling = NullValueHandling.Ignore,
-                    ContractResolver = new CreateableContractResolver()
+                    ContractResolver = new CreateableContractResolver(),
+                    DateFormatString = DateFormat
                 });
 
             var content = new StringContent(json, Encoding.UTF8, "application/json");
@@ -184,6 +186,7 @@ namespace Salesforce.Common
                 new JsonSerializerSettings
                 {
                     NullValueHandling = NullValueHandling.Ignore,
+                    DateFormatString = DateFormat
                 });
 
             var content = new StringContent(json, Encoding.UTF8, "application/json");
@@ -214,7 +217,8 @@ namespace Salesforce.Common
                 Formatting.None,
                 new JsonSerializerSettings
                 {
-                    ContractResolver = new UpdateableContractResolver()
+                    ContractResolver = new UpdateableContractResolver(),
+                    DateFormatString = DateFormat
                 });
 
             request.Content = new StringContent(json, Encoding.UTF8, "application/json");


### PR DESCRIPTION
Sfdc responds with the error message Salesforce.Common.ForceException: Cannot deserialize instance of date from VALUE_STRING value 2015-07-23T09:38:33.6366008+02:00 at [line:1, column:268] when posting a sObject containing a DateTime.

This PR overrides Newtonsoft.JSONs default serialization DateTime format.

There might be a timezone issue left...

I'm not sure about commit f3241f7. I guess the original author forgot to add the line at this point. Might also be intended.