### PR TITLE
Fixing how Custom Rest URl's are generated

### DIFF
--- a/scripts/build.cmd
+++ b/scripts/build.cmd
@@ -1,4 +1,4 @@
-"assets\NuGet.exe" restore "src\ForceToolkitForNET.sln" -ConfigFile "assets\NuGet.Config" -Source nuget -Verbosity detailed -NoCache -DisableParallelProcessing
+"scripts\assets\NuGet.exe" restore "src\ForceToolkitForNET.sln" -ConfigFile "assets\NuGet.Config" -Source nuget -Verbosity detailed -NoCache -DisableParallelProcessing
 
 "C:\Program Files (x86)\MSBuild\12.0\bin\msbuild.exe" "src\ForceToolkitForNET.sln" /verbosity:minimal /target:Clean
 

--- a/scripts/build.cmd
+++ b/scripts/build.cmd
@@ -1,7 +1,7 @@
-"assets\NuGet.exe" restore "..\src\ForceToolkitForNET.sln" -ConfigFile "assets\NuGet.Config" -Source nuget -Verbosity detailed -NoCache -DisableParallelProcessing
+"assets\NuGet.exe" restore "src\ForceToolkitForNET.sln" -ConfigFile "assets\NuGet.Config" -Source nuget -Verbosity detailed -NoCache -DisableParallelProcessing
 
-"C:\Program Files (x86)\MSBuild\12.0\bin\msbuild.exe" "..\src\ForceToolkitForNET.sln" /verbosity:minimal /target:Clean
+"C:\Program Files (x86)\MSBuild\12.0\bin\msbuild.exe" "src\ForceToolkitForNET.sln" /verbosity:minimal /target:Clean
 
-"C:\Program Files (x86)\MSBuild\12.0\bin\msbuild.exe" "..\src\ForceToolkitForNET.sln" /verbosity:minimal /target:Rebuild /property:Configuration=Debug
+"C:\Program Files (x86)\MSBuild\12.0\bin\msbuild.exe" "src\ForceToolkitForNET.sln" /verbosity:minimal /target:Rebuild /property:Configuration=Debug
 
-"C:\Program Files (x86)\MSBuild\12.0\bin\msbuild.exe" "..\src\ForceToolkitForNET.sln" /verbosity:minimal /target:Rebuild /property:Configuration=Release
+"C:\Program Files (x86)\MSBuild\12.0\bin\msbuild.exe" "src\ForceToolkitForNET.sln" /verbosity:minimal /target:Rebuild /property:Configuration=Release

--- a/scripts/build.cmd
+++ b/scripts/build.cmd
@@ -1,4 +1,4 @@
-"scripts\assets\NuGet.exe" restore "src\ForceToolkitForNET.sln" -ConfigFile "assets\NuGet.Config" -Source nuget -Verbosity detailed -NoCache -DisableParallelProcessing
+"scripts\assets\NuGet.exe" restore "src\ForceToolkitForNET.sln" -ConfigFile "scripts\assets\NuGet.Config" -Source nuget -Verbosity detailed -NoCache -DisableParallelProcessing
 
 "C:\Program Files (x86)\MSBuild\12.0\bin\msbuild.exe" "src\ForceToolkitForNET.sln" /verbosity:minimal /target:Clean
 

--- a/src/CommonLibrariesForNET/Common.cs
+++ b/src/CommonLibrariesForNET/Common.cs
@@ -26,13 +26,13 @@ namespace Salesforce.Common
         /// <param name="parameters">Pre-formatted parameters like this: ?name1=value1&name2=value2&soon=soforth</param>
         /// <param name="instanceUrl">Instance url returned from auth</param>
         /// <returns>String: The formatted Url</returns>
-        public static string FormatCustomUrl(string customAPI, string parameters, string instanceUrl)
+        public static Uri FormatCustomUrl(string customAPI, string parameters, string instanceUrl)
         {
             if (string.IsNullOrEmpty(customAPI)) throw new ArgumentNullException("customAPI");
             if (string.IsNullOrEmpty(parameters)) throw new ArgumentNullException("parameters");
             if (string.IsNullOrEmpty(instanceUrl)) throw new ArgumentNullException("instanceUrl");
 
-            return string.Format("{0}/services/apexrest/{1}{2}", instanceUrl, customAPI, parameters);
+            return new Uri(string.Format("{0}/services/apexrest/{1}{2}", instanceUrl, customAPI, parameters));
         }
         
 		public static string FormatAuthUrl(

--- a/src/CommonLibrariesForNET/Common.cs
+++ b/src/CommonLibrariesForNET/Common.cs
@@ -34,6 +34,14 @@ namespace Salesforce.Common
 
             return new Uri(string.Format("{0}/services/apexrest/{1}{2}", instanceUrl, customAPI, parameters));
         }
+
+        public static Uri FormatCustomUrl(string customAPI, string instanceUrl)
+        {
+            if (string.IsNullOrEmpty(customAPI)) throw new ArgumentNullException("customAPI");
+            if (string.IsNullOrEmpty(instanceUrl)) throw new ArgumentNullException("instanceUrl");
+
+            return new Uri(string.Format("{0}/services/apexrest/{1}", instanceUrl, customAPI));
+        }
         
 		public static string FormatAuthUrl(
             string loginUrl,

--- a/src/CommonLibrariesForNET/ServiceHttpClient.cs
+++ b/src/CommonLibrariesForNET/ServiceHttpClient.cs
@@ -86,7 +86,14 @@ namespace Salesforce.Common
 
             return await HttpGetAsync<T>(url);
         }
-        
+
+        public async Task<T> HttpPostRestApiAsync<T>(string apiName, object inputObject)
+        {
+            var url = Common.FormatCustomUrl(apiName, _instanceUrl);
+
+            return await HttpPostAsync<T>(inputObject, url);
+        }
+
 		public async Task<IList<T>> HttpGetAsync<T>(string urlSuffix, string nodeName)
         {
             string next = null;

--- a/src/ForceToolkitForNET/ForceClient.cs
+++ b/src/ForceToolkitForNET/ForceClient.cs
@@ -56,6 +56,15 @@ namespace Salesforce.Force
             var response = await _serviceHttpClient.HttpGetRestApiAsync<T>(apiName, parameters);
             return response;
         }
+
+        public async Task<T> ExecuteRestApiPost<T>(string apiName, object inputObject)
+        {
+            if (string.IsNullOrEmpty(apiName)) throw new ArgumentNullException("apiName");
+            if (inputObject == null) throw new ArgumentNullException("inputObject");
+
+            var response = await _serviceHttpClient.HttpPostRestApiAsync<T>(apiName, inputObject);
+            return response;
+        }
         
 		public async Task<T> QueryByIdAsync<T>(string objectName, string recordId)
         {

--- a/src/ForceToolkitForNET/IForceClient.cs
+++ b/src/ForceToolkitForNET/IForceClient.cs
@@ -11,6 +11,7 @@ namespace Salesforce.Force
         Task<QueryResult<T>> QueryAllAsync<T>(string query);
         Task<T> QueryByIdAsync<T>(string objectName, string recordId);
 		Task<T> ExecuteRestApi<T>(string apiName, string parameters);
+        Task<T> ExecuteRestApiPost<T>(string apiName, object inputObject);
         Task<string> CreateAsync(string objectName, object record);
         Task<SuccessResponse> UpdateAsync(string objectName, string recordId, object record);
         Task<SuccessResponse> UpsertExternalAsync(string objectName, string externalFieldName, string externalId, object record);


### PR DESCRIPTION
The FormatCustom URL was returning a string and therefore did not call
the correct HttpGetAsync<>() method. calling the string overload instead
of the Uri overload.  changing the type now to be a Uri will fix this.

This fixes issue  #130 
