### PR TITLE
CreateAsync return type fixed in sample console app

### DIFF
--- a/samples/SimpleConsole/Program.cs
+++ b/samples/SimpleConsole/Program.cs
@@ -91,8 +91,8 @@ namespace SimpleConsole
             // Create a sample record
             Console.WriteLine("Creating test record.");
             var account = new Account { Name = "Test Account" };
-            account.Id = await client.CreateAsync(Account.SObjectTypeName, account);
-            if (account.Id == null)
+            var response = await client.CreateAsync(Account.SObjectTypeName, account);
+            if (!string.Equals(response.Success, "true", StringComparison.OrdinalIgnoreCase))
             {
                 Console.WriteLine("Failed to create test record.");
                 return;


### PR DESCRIPTION
Hello,
it seems that sample console app is not up to date, which might be confusing to some users:
http://salesforce.stackexchange.com/q/95884/13265

Here's my small fix.
