### PR TITLE
Enable Gzip encoding in the ServiceHttpClient requests 

### DIFF
--- a/src/CommonLibrariesForNET/CommonLibrariesForNET.csproj
+++ b/src/CommonLibrariesForNET/CommonLibrariesForNET.csproj
@@ -45,6 +45,7 @@
     <Compile Include="AuthenticationClient.cs" />
     <Compile Include="Common.cs" />
     <Compile Include="Attributes\CreateableAttribute.cs" />
+    <Compile Include="Extensions\HttpContentCompressedDataExtensions.cs" />
     <Compile Include="Models\DescribeGlobalResult.cs" />
     <Compile Include="Models\DisplayTypes.cs" />
     <Compile Include="ForceAuthException.cs" />
@@ -71,7 +72,9 @@
     <None Include="app.config">
       <SubType>Designer</SubType>
     </None>
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Threading.Tasks">
@@ -84,6 +87,10 @@
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\portable-net40+sl5+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.IO.Compression">
+      <HintPath>..\packages\Microsoft.Bcl.Compression.3.9.85\lib\portable-net45+win8+wp8+wpa81\System.IO.Compression.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Net.Http">
@@ -106,6 +113,11 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))" />
+  </Target>
+  <Import Project="..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" />
+  <Target Name="EnsureBclBuildImported" BeforeTargets="BeforeBuild" Condition="'$(BclBuildImported)' == ''">
+    <Error Condition="!Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=317567." HelpKeyword="BCLBUILD2001" />
+    <Error Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="The build restored NuGet packages. Build the project again to include these packages in the build. For more information, see http://go.microsoft.com/fwlink/?LinkID=317568." HelpKeyword="BCLBUILD2002" />
   </Target>
   <Import Project="..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" />
   <Target Name="EnsureBclBuildImported" BeforeTargets="BeforeBuild" Condition="'$(BclBuildImported)' == ''">

--- a/src/CommonLibrariesForNET/Extensions/HttpContentCompressedDataExtensions.cs
+++ b/src/CommonLibrariesForNET/Extensions/HttpContentCompressedDataExtensions.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+
+namespace Salesforce.Common
+{
+    /// <summary>
+    /// Extension methods for <see cref="HttpContent"/>.
+    /// </summary>
+    public static class HttpContentCompressedDataExtensions
+    {
+        /// <summary>
+        /// Content-Encoding default value 
+        /// </summary>
+        public const string GZipEncoding = "gzip";
+
+        /// <summary>
+        /// Returns the response content to string. It decompresses the content if needed
+        /// </summary>
+        /// <param name="responseContent">Http Response Message</param>
+        /// <returns>Http Response content as string</returns>
+        public static async Task<string> ReadAsDecompressedStringAsync(this HttpContent responseContent)
+        {
+            string content;
+
+            if (responseContent == null)
+            {
+                return string.Empty;
+            }
+
+            // Check if the response content is gzip encoded. Gzipped response length is less than the actual and thereby less 
+            // payload over the network.
+            if (responseContent.Headers.ContentEncoding.Contains(GZipEncoding,StringComparer.OrdinalIgnoreCase))
+            {
+                var responseStream = await responseContent.ReadAsStreamAsync().ConfigureAwait(false);
+                var unzippedContent = new GZipStream(responseStream, CompressionMode.Decompress);
+                content = await(new StreamReader(unzippedContent)).ReadToEndAsync();
+            }
+            else
+            {
+                content = await responseContent.ReadAsStringAsync().ConfigureAwait(false);
+            }
+
+            return content;
+        }
+    }
+}

--- a/src/CommonLibrariesForNET/packages.config
+++ b/src/CommonLibrariesForNET/packages.config
@@ -3,6 +3,8 @@
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="portable-net45+win8+wp8" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="portable-net45+win8+wp8" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="portable-net45+win8+wp8" />
+  <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="portable-net45+win+wp80" />
+  <package id="Microsoft.Bcl.Compression" version="3.9.85" targetFramework="portable-net45+win+wp80" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="portable-net45+win8+wp8" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="portable45-net45+win8+wp8" />
 </packages>

--- a/src/ForceToolkitForNET/ForceClient.cs
+++ b/src/ForceToolkitForNET/ForceClient.cs
@@ -14,17 +14,11 @@ namespace Salesforce.Force
     {
         private readonly ServiceHttpClient _serviceHttpClient;
 
-        public ForceClient(string instanceUrl, string accessToken, string apiVersion)
-            : this(instanceUrl, accessToken, apiVersion, new HttpClient())
-        {
-        }
-
-        public ForceClient(string instanceUrl, string accessToken, string apiVersion, HttpClient httpClient)
+        public ForceClient(string instanceUrl, string accessToken, string apiVersion, HttpClient httpClient = null)
         {
             if (string.IsNullOrEmpty(instanceUrl)) throw new ArgumentNullException("instanceUrl");
             if (string.IsNullOrEmpty(accessToken)) throw new ArgumentNullException("accessToken");
             if (string.IsNullOrEmpty(apiVersion)) throw new ArgumentNullException("apiVersion");
-            if (httpClient == null) throw new ArgumentNullException("httpClient");
 
             _serviceHttpClient = new ServiceHttpClient(instanceUrl, apiVersion, accessToken, httpClient);
         }


### PR DESCRIPTION
1. Enable Gzip encoding in the ServiceHttpClient requests
2. Do not dispose HttpClient that is provided to ServiceHttpClient because it is external to it and can be a shared one. Dispose HttpClient only if it is created by ServiceHttpClient