### PR TITLE
Add ability to query blob object contents

### DIFF
--- a/src/CommonLibrariesForNET/ServiceHttpClient.cs
+++ b/src/CommonLibrariesForNET/ServiceHttpClient.cs
@@ -38,6 +38,29 @@ namespace Salesforce.Common
             _httpClient.Dispose();
         }
 
+        public async Task<System.IO.Stream> HttpGetBlobAsync(string urlSuffix)
+        {
+            var uri = Common.FormatUrl(urlSuffix, _instanceUrl, ApiVersion);
+
+            var request = new HttpRequestMessage
+            {
+                RequestUri = uri,
+                Method = HttpMethod.Get
+            };
+
+            var responseMessage = await _httpClient.SendAsync(request).ConfigureAwait(false);
+            var response = await responseMessage.Content.ReadAsStreamAsync();
+
+            if (responseMessage.IsSuccessStatusCode)
+            {
+                return response;
+            }
+            else
+            {
+                return new System.IO.MemoryStream();
+            }
+        }
+
         public async Task<T> HttpGetAsync<T>(string urlSuffix)
         {
             var uri = Common.FormatUrl(urlSuffix, _instanceUrl, ApiVersion);

--- a/src/ForceToolkitForNET.FunctionalTests/ForceClientTests.cs
+++ b/src/ForceToolkitForNET.FunctionalTests/ForceClientTests.cs
@@ -592,6 +592,26 @@ namespace Salesforce.Force.FunctionalTests
         }
 
         [Test]
+        public async void QueryBlobContents()
+        {            
+            var success = await _client.CreateAsync("Account", new Account { Name = "Test Account", Description = "New Account Description" });
+            Assert.IsNotNull(success.Id);
+
+            String accountId = success.Id;
+            String input = "QueryBlobContents - Unit Test";
+            var contents = System.Text.Encoding.UTF8.GetBytes(input);
+            success = await _client.CreateAsync("Attachment", new { ParentId = accountId, Name = "BlobFunctionalTest.txt", Body = contents });
+
+            String attachmentId = success.Id;
+            var stream = await _client.GetBlobAsync("Attachment", attachmentId, "Body");
+            using (System.IO.StreamReader reader = new System.IO.StreamReader(stream))
+            {
+                var output = reader.ReadToEnd();
+                Assert.AreEqual(input, output);
+            }
+        }
+
+        [Test]
         public async void SearchAsync()
         {
             var result = await _client.SearchAsync<dynamic>("FIND {test}");

--- a/src/ForceToolkitForNET/ForceClient.cs
+++ b/src/ForceToolkitForNET/ForceClient.cs
@@ -49,6 +49,15 @@ namespace Salesforce.Force
 
             return _serviceHttpClient.HttpGetAsync<QueryResult<T>>(string.Format("queryAll/?q={0}", Uri.EscapeDataString(query)));
         }
+
+        public async Task<System.IO.Stream> GetBlobAsync(String objectName, String objectId, String fieldName)
+        {
+            if (string.IsNullOrEmpty(objectName)) throw new ArgumentNullException(nameof(objectName));
+            if (string.IsNullOrEmpty(objectId)) throw new ArgumentNullException(nameof(objectId));
+            if (string.IsNullOrEmpty(fieldName)) throw new ArgumentNullException(nameof(fieldName));
+
+            return await _serviceHttpClient.HttpGetBlobAsync($"sobjects/{objectName}/{objectId}/{fieldName}");
+        }
         
         public async Task<T> ExecuteRestApiAsync<T>(string apiName)
         {


### PR DESCRIPTION
Example usage would be to get attachment contents out of SalesForce.

forceClient.GetBlobAsync("Attachment", attachmentId, "Body");
