### PR TITLE
Ability to add custom HTTP headers

### DIFF
--- a/src/ChatterToolkitForNET/ChatterClient.cs
+++ b/src/ChatterToolkitForNET/ChatterClient.cs
@@ -3,6 +3,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Salesforce.Chatter.Models;
 using Salesforce.Common;
+using Salesforce.Common.Models;
 
 namespace Salesforce.Chatter
 {
@@ -41,7 +42,7 @@ namespace Salesforce.Chatter
             {
                 return _serviceHttpClient.HttpPostAsync<T>(feedItemInput, "chatter/feed-elements");
             }
-               
+
             return _serviceHttpClient.HttpPostAsync<T>(feedItemInput, string.Format("chatter/feeds/news/{0}/{1}", userId, _itemsOrElements));
         }
 
@@ -61,7 +62,7 @@ namespace Salesforce.Chatter
             {
                 return _serviceHttpClient.HttpPostAsync<T>(envelope, string.Format("chatter/{0}/{1}/capabilities/comments/items", _itemsOrElements, feedId));
             }
-            
+
             return _serviceHttpClient.HttpPostAsync<T>(envelope, string.Format("chatter/{0}/{1}/comments", _itemsOrElements, feedId));
         }
 
@@ -71,7 +72,7 @@ namespace Salesforce.Chatter
             {
                 return _serviceHttpClient.HttpPostAsync<T>(null, string.Format("chatter/{0}/{1}/capabilities/chatter-likes/items", _itemsOrElements, feedId));
             }
-         
+
             return _serviceHttpClient.HttpPostAsync<T>(null, string.Format("chatter/{0}/{1}/likes", _itemsOrElements, feedId));
         }
 

--- a/src/ChatterToolkitForNET/IChatterClient.cs
+++ b/src/ChatterToolkitForNET/IChatterClient.cs
@@ -1,5 +1,6 @@
 using System.Threading.Tasks;
 using Salesforce.Chatter.Models;
+using Salesforce.Common.Models;
 
 namespace Salesforce.Chatter
 {
@@ -9,6 +10,8 @@ namespace Salesforce.Chatter
         Task<T> MeAsync<T>();
         Task<T> PostFeedItemAsync<T>(FeedItemInput feedItemInput, string userId);
         Task<T> PostFeedItemCommentAsync<T>(FeedItemInput envelope, string feedId);
+        Task<T> PostFeedItemToObjectAsync<T>(ObjectFeedItemInput envelope);
+        Task<T> PostFeedItemWithAttachmentAsync<T>(ObjectFeedItemInput envelope, byte[] fileContents, string fileName);
         Task<T> LikeFeedItemAsync<T>(string feedId);
         Task<T> ShareFeedItemAsync<T>(string feedId, string userId);
         Task<T> GetMyNewsFeedAsync<T>(string query = "");

--- a/src/CommonLibrariesForNET/IServiceHttpClient.cs
+++ b/src/CommonLibrariesForNET/IServiceHttpClient.cs
@@ -13,9 +13,15 @@ namespace Salesforce.Common
         Task<IList<T>> HttpGetAsync<T>(string urlSuffix, string nodeName);
         Task<T> HttpGetAsync<T>(Uri uri);
         Task<T> HttpPostRestApiAsync<T>(string apiName, object inputObject);
+
         Task<T> HttpPostAsync<T>(object inputObject, string urlSuffix);
+        Task<T> HttpPostAsync<T>(object inputObject, string urlSuffix, Dictionary<string, string> headers);
         Task<T> HttpPostAsync<T>(object inputObject, Uri uri);
+        Task<T> HttpPostAsync<T>(object inputObject, Uri uri, Dictionary<string, string> headers);
+        
         Task<SuccessResponse> HttpPatchAsync(object inputObject, string urlSuffix);
+        Task<SuccessResponse> HttpPatchAsync(object inputObject, string urlSuffix, Dictionary<string, string> headers);
+        
         Task<bool> HttpDeleteAsync(string urlSuffix);
         Task<T> HttpBinaryDataPostAsync<T>(string urlSuffix, object inputObject, byte[] fileContents, string headerName, string fileName);
     }

--- a/src/CommonLibrariesForNET/ServiceHttpClient.cs
+++ b/src/CommonLibrariesForNET/ServiceHttpClient.cs
@@ -161,20 +161,12 @@ namespace Salesforce.Common
         public async Task<T> HttpPostAsync<T>(object inputObject, string urlSuffix, Dictionary<string, string> headers)
         {
             var uri = Common.FormatUrl(urlSuffix, _instanceUrl, ApiVersion);
-            var json = JsonConvert.SerializeObject(inputObject,
-                Formatting.None,
-                new JsonSerializerSettings
-                {
-                    NullValueHandling = NullValueHandling.Ignore,
-                    ContractResolver = new CreateableContractResolver(),
-                    DateFormatString = DateFormat
-                });
-
 
             var request = new HttpRequestMessage
             {
                 RequestUri = uri,
-                Method = new HttpMethod("POST")
+                Method = new HttpMethod("POST"),
+
             };
 
             if (headers != null)
@@ -185,7 +177,16 @@ namespace Salesforce.Common
                 }
             }
 
-            var content = new StringContent(json, Encoding.UTF8, "application/json");
+            var json = JsonConvert.SerializeObject(inputObject,
+                Formatting.None,
+                new JsonSerializerSettings
+                {
+                    NullValueHandling = NullValueHandling.Ignore,
+                    ContractResolver = new CreateableContractResolver(),
+                    DateFormatString = DateFormat
+                });
+
+            request.Content = new StringContent(json, Encoding.UTF8, "application/json");
 
             var responseMessage = await _httpClient.SendAsync(request).ConfigureAwait(false);
             var response = await responseMessage.Content.ReadAsStringAsync().ConfigureAwait(false);

--- a/src/CommonLibrariesForNET/ServiceHttpClient.cs
+++ b/src/CommonLibrariesForNET/ServiceHttpClient.cs
@@ -154,6 +154,12 @@ namespace Salesforce.Common
 
         public async Task<T> HttpPostAsync<T>(object inputObject, string urlSuffix)
         {
+            return await HttpPostAsync<T>(inputObject, urlSuffix, null);
+        }
+
+
+        public async Task<T> HttpPostAsync<T>(object inputObject, string urlSuffix, Dictionary<string, string> headers)
+        {
             var uri = Common.FormatUrl(urlSuffix, _instanceUrl, ApiVersion);
             var json = JsonConvert.SerializeObject(inputObject,
                 Formatting.None,
@@ -164,9 +170,24 @@ namespace Salesforce.Common
                     DateFormatString = DateFormat
                 });
 
+
+            var request = new HttpRequestMessage
+            {
+                RequestUri = uri,
+                Method = new HttpMethod("POST")
+            };
+
+            if (headers != null)
+            {
+                foreach (var h in headers)
+                {
+                    request.Headers.Add(h.Key, h.Value);
+                }
+            }
+
             var content = new StringContent(json, Encoding.UTF8, "application/json");
 
-            var responseMessage = await _httpClient.PostAsync(uri, content).ConfigureAwait(false);
+            var responseMessage = await _httpClient.SendAsync(request).ConfigureAwait(false);
             var response = await responseMessage.Content.ReadAsStringAsync().ConfigureAwait(false);
 
             if (responseMessage.IsSuccessStatusCode)
@@ -181,6 +202,11 @@ namespace Salesforce.Common
 
         public async Task<T> HttpPostAsync<T>(object inputObject, Uri uri)
         {
+            return await HttpPostAsync<T>(inputObject, uri, null);
+        }
+
+        public async Task<T> HttpPostAsync<T>(object inputObject, Uri uri, Dictionary<string, string> headers)
+        {
             var json = JsonConvert.SerializeObject(inputObject,
                 Formatting.None,
                 new JsonSerializerSettings
@@ -189,8 +215,22 @@ namespace Salesforce.Common
                     DateFormatString = DateFormat
                 });
 
+            var request = new HttpRequestMessage
+            {
+                RequestUri = uri,
+                Method = new HttpMethod("POST")
+            };
+
+            if (headers != null)
+            {
+                foreach (var h in headers)
+                {
+                    request.Headers.Add(h.Key, h.Value);
+                }
+            }
+
             var content = new StringContent(json, Encoding.UTF8, "application/json");
-            var responseMessage = await _httpClient.PostAsync(uri, content).ConfigureAwait(false);
+            var responseMessage = await _httpClient.SendAsync(request).ConfigureAwait(false);
             var response = await responseMessage.Content.ReadAsStringAsync().ConfigureAwait(false);
 
             if (responseMessage.IsSuccessStatusCode)
@@ -205,6 +245,12 @@ namespace Salesforce.Common
 
         public async Task<SuccessResponse> HttpPatchAsync(object inputObject, string urlSuffix)
         {
+            return await HttpPatchAsync(inputObject, urlSuffix, null);
+        }
+
+
+        public async Task<SuccessResponse> HttpPatchAsync(object inputObject, string urlSuffix, Dictionary<string, string> headers)
+        {
             var uri = Common.FormatUrl(urlSuffix, _instanceUrl, ApiVersion);
 
             var request = new HttpRequestMessage
@@ -212,6 +258,14 @@ namespace Salesforce.Common
                 RequestUri = uri,
                 Method = new HttpMethod("PATCH")
             };
+
+            if (headers != null)
+            {
+                foreach (var h in headers)
+                {
+                    request.Headers.Add(h.Key, h.Value);
+                }
+            }
 
             var json = JsonConvert.SerializeObject(inputObject,
                 Formatting.None,
@@ -243,6 +297,7 @@ namespace Salesforce.Common
             var errorResponse = JsonConvert.DeserializeObject<ErrorResponses>(error);
             throw new ForceException(errorResponse[0].ErrorCode, errorResponse[0].Message);
         }
+        
 
         public async Task<bool> HttpDeleteAsync(string urlSuffix)
         {

--- a/src/ForceToolkitForNET/ForceClient.cs
+++ b/src/ForceToolkitForNET/ForceClient.cs
@@ -84,6 +84,7 @@ namespace Salesforce.Force
             return results.Records.FirstOrDefault();
         }
 
+
         public async Task<SuccessResponse> CreateAsync(string objectName, object record)
         {
             if (string.IsNullOrEmpty(objectName)) throw new ArgumentNullException("objectName");
@@ -91,6 +92,25 @@ namespace Salesforce.Force
 
             return await _serviceHttpClient.HttpPostAsync<SuccessResponse>(record, string.Format("sobjects/{0}", objectName)).ConfigureAwait(false);
         }
+
+        public async Task<SuccessResponse> CreateAsync(string objectName, object record, Dictionary<string, string> headers)
+        {
+            if (string.IsNullOrEmpty(objectName)) throw new ArgumentNullException("objectName");
+            if (record == null) throw new ArgumentNullException("record");
+
+            return await _serviceHttpClient.HttpPostAsync<SuccessResponse>(record, string.Format("sobjects/{0}", objectName), headers).ConfigureAwait(false);
+        }
+
+
+        public Task<SuccessResponse> UpdateAsync(string objectName, string recordId, object record, Dictionary<string, string> headers)
+        {
+            if (string.IsNullOrEmpty(objectName)) throw new ArgumentNullException("objectName");
+            if (string.IsNullOrEmpty(recordId)) throw new ArgumentNullException("recordId");
+            if (record == null) throw new ArgumentNullException("record");
+
+            return _serviceHttpClient.HttpPatchAsync(record, string.Format("sobjects/{0}/{1}", objectName, recordId), headers);
+        }
+
 
         public Task<SuccessResponse> UpdateAsync(string objectName, string recordId, object record)
         {
@@ -110,6 +130,22 @@ namespace Salesforce.Force
 
             return _serviceHttpClient.HttpPatchAsync(record, string.Format("sobjects/{0}/{1}/{2}", objectName, externalFieldName, externalId));
         }
+
+        public Task<SuccessResponse> UpsertExternalAsync(string objectName, string externalFieldName, string externalId, object record, Dictionary<string, string> headers)
+        {
+            if (string.IsNullOrEmpty(objectName)) throw new ArgumentNullException("objectName");
+            if (string.IsNullOrEmpty(externalFieldName)) throw new ArgumentNullException("externalFieldName");
+            if (string.IsNullOrEmpty(externalId)) throw new ArgumentNullException("externalId");
+            if (record == null) throw new ArgumentNullException("record");
+
+            return _serviceHttpClient.HttpPatchAsync(record, string.Format("sobjects/{0}/{1}/{2}", objectName, externalFieldName, externalId), headers);
+        }
+
+
+
+
+
+
 
         public Task<bool> DeleteAsync(string objectName, string recordId)
         {

--- a/src/ForceToolkitForNET/IForceClient.cs
+++ b/src/ForceToolkitForNET/IForceClient.cs
@@ -23,8 +23,6 @@ namespace Salesforce.Force
         Task<SuccessResponse> UpsertExternalAsync(string objectName, string externalFieldName, string externalId, object record);
         Task<SuccessResponse> UpsertExternalAsync(string objectName, string externalFieldName, string externalId, object record, Dictionary<string, string> headers);
 
-        
-        
         Task<bool> DeleteAsync(string objectName, string recordId);
         Task<bool> DeleteExternalAsync(string objectName, string externalFieldName, string externalId);
         Task<DescribeGlobalResult<T>> GetObjectsAsync<T>();

--- a/src/ForceToolkitForNET/IForceClient.cs
+++ b/src/ForceToolkitForNET/IForceClient.cs
@@ -13,9 +13,18 @@ namespace Salesforce.Force
         Task<T> QueryByIdAsync<T>(string objectName, string recordId);
         Task<T> ExecuteRestApiAsync<T>(string apiName);
         Task<T> ExecuteRestApiAsync<T>(string apiName, object inputObject);
+
         Task<SuccessResponse> CreateAsync(string objectName, object record);
+        Task<SuccessResponse> CreateAsync(string objectName, object record, Dictionary<string, string> headers);
+
         Task<SuccessResponse> UpdateAsync(string objectName, string recordId, object record);
+        Task<SuccessResponse> UpdateAsync(string objectName, string recordId, object record, Dictionary<string, string> headers);
+
         Task<SuccessResponse> UpsertExternalAsync(string objectName, string externalFieldName, string externalId, object record);
+        Task<SuccessResponse> UpsertExternalAsync(string objectName, string externalFieldName, string externalId, object record, Dictionary<string, string> headers);
+
+        
+        
         Task<bool> DeleteAsync(string objectName, string recordId);
         Task<bool> DeleteExternalAsync(string objectName, string externalFieldName, string externalId);
         Task<DescribeGlobalResult<T>> GetObjectsAsync<T>();


### PR DESCRIPTION
Adds ability to send custom headers in requests for both POST and PATCH
requests. This would allow the library, for example, to disable
assignment rules when creating or updating a case.
