### PR TITLE
Clearing HttpClient Default User Agent Headers before adding the User Agent Headers

### DIFF
--- a/src/CommonLibrariesForNET.UnitTests/CommonTests.cs
+++ b/src/CommonLibrariesForNET.UnitTests/CommonTests.cs
@@ -159,5 +159,21 @@ namespace Salesforce.Common.UnitTests
                 await httpClient.HttpGetAsync<object>("wade");
             }
         }
+
+        [Test]
+        public void NewServiceHttpClient_ResetsUserAgents()
+        {
+            var httpClientUserAgent = UserAgent + "/v34";
+
+            var httpClient = new HttpClient();
+            httpClient.DefaultRequestHeaders.UserAgent.ParseAdd(httpClientUserAgent);
+            httpClient.DefaultRequestHeaders.UserAgent.ParseAdd(httpClientUserAgent);
+            Assert.AreEqual(httpClientUserAgent + " " + httpClientUserAgent, httpClient.DefaultRequestHeaders.UserAgent.ToString());
+
+            var serviceClient = new ServiceHttpClient("http://localhost:1899", "v34", "accessToken", httpClient);
+
+            // Ensure the old user agent header is replaced.
+            Assert.AreEqual(httpClientUserAgent, httpClient.DefaultRequestHeaders.UserAgent.ToString());
+        }
     }
 }

--- a/src/CommonLibrariesForNET/ServiceHttpClient.cs
+++ b/src/CommonLibrariesForNET/ServiceHttpClient.cs
@@ -33,14 +33,15 @@ namespace Salesforce.Common
             }
             else
             {
-                _httpClient = httpClient;    
+                _httpClient = httpClient;
             }
 
+            _httpClient.DefaultRequestHeaders.UserAgent.Clear();
             _httpClient.DefaultRequestHeaders.UserAgent.ParseAdd(string.Concat(UserAgent, "/", ApiVersion));
             _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
 
             _httpClient.DefaultRequestHeaders.Accept.Clear();
-            _httpClient.DefaultRequestHeaders.AcceptEncoding.Clear(); 
+            _httpClient.DefaultRequestHeaders.AcceptEncoding.Clear();
             _httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
             _httpClient.DefaultRequestHeaders.AcceptEncoding.Add(new StringWithQualityHeaderValue("gzip"));
         }


### PR DESCRIPTION
Otherwise, as/if HttpClient is reused, the header size grows until Salesforce throwing 413 error responses, which then the Force Client does not know how to handle.