### PR TITLE
Updated Newtonsoft.Json nuget to 8.0.1.

### DIFF
--- a/src/ChatterToolkitForNET.FunctionalTests/ChatterToolkitForNET.FunctionalTests.csproj
+++ b/src/ChatterToolkitForNET.FunctionalTests/ChatterToolkitForNET.FunctionalTests.csproj
@@ -47,8 +47,8 @@
       <HintPath>..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.Desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.8.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework">

--- a/src/ChatterToolkitForNET.FunctionalTests/packages.config
+++ b/src/ChatterToolkitForNET.FunctionalTests/packages.config
@@ -5,6 +5,6 @@
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net45" />
   <package id="Microsoft.Bcl.Compression" version="3.9.85" targetFramework="net45" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="8.0.1" targetFramework="net45" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
 </packages>

--- a/src/ChatterToolkitForNET/ChatterToolkitForNET.csproj
+++ b/src/ChatterToolkitForNET/ChatterToolkitForNET.csproj
@@ -103,8 +103,9 @@
     <Reference Include="Microsoft.Threading.Tasks.Extensions">
       <HintPath>..\packages\Microsoft.Bcl.Async.1.0.168\lib\portable-net45+win8+wp8+wpa81\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\portable-net40+sl5+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.8.0.1\lib\portable-net45+wp80+win8+wpa81+dnxcore50\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.IO.Compression">
       <HintPath>..\packages\Microsoft.Bcl.Compression.3.9.85\lib\portable-net45+win8+wp8+wpa81\System.IO.Compression.dll</HintPath>

--- a/src/ChatterToolkitForNET/packages.config
+++ b/src/ChatterToolkitForNET/packages.config
@@ -5,5 +5,5 @@
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="portable-net45+win8+wp8" />
   <package id="Microsoft.Bcl.Compression" version="3.9.85" targetFramework="net45" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="portable-net45+win8+wp8" />
-  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="portable45-net45+win8+wp8" />
+  <package id="Newtonsoft.Json" version="8.0.1" targetFramework="portable-net45+win+wp80" />
 </packages>

--- a/src/CommonLibrariesForNET.FunctionalTests/CommonLibrariesForNET.FunctionalTests.csproj
+++ b/src/CommonLibrariesForNET.FunctionalTests/CommonLibrariesForNET.FunctionalTests.csproj
@@ -47,8 +47,8 @@
       <HintPath>..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.Desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.8.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework">

--- a/src/CommonLibrariesForNET.FunctionalTests/packages.config
+++ b/src/CommonLibrariesForNET.FunctionalTests/packages.config
@@ -5,6 +5,6 @@
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net45" />
   <package id="Microsoft.Bcl.Compression" version="3.9.85" targetFramework="net45" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="8.0.1" targetFramework="net45" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
 </packages>

--- a/src/CommonLibrariesForNET.UnitTests/CommonLibrariesForNET.UnitTests.csproj
+++ b/src/CommonLibrariesForNET.UnitTests/CommonLibrariesForNET.UnitTests.csproj
@@ -47,8 +47,8 @@
       <HintPath>..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.Desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.8.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework">

--- a/src/CommonLibrariesForNET.UnitTests/packages.config
+++ b/src/CommonLibrariesForNET.UnitTests/packages.config
@@ -4,6 +4,6 @@
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net45" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net45" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="8.0.1" targetFramework="net45" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
 </packages>

--- a/src/CommonLibrariesForNET/CommonLibrariesForNET.csproj
+++ b/src/CommonLibrariesForNET/CommonLibrariesForNET.csproj
@@ -83,8 +83,9 @@
     <Reference Include="Microsoft.Threading.Tasks.Extensions">
       <HintPath>..\packages\Microsoft.Bcl.Async.1.0.168\lib\portable-net45+win8+wp8+wpa81\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\portable-net40+sl5+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.8.0.1\lib\portable-net45+wp80+win8+wpa81+dnxcore50\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.IO.Compression">
       <HintPath>..\packages\Microsoft.Bcl.Compression.3.9.85\lib\portable-net45+win8+wp8+wpa81\System.IO.Compression.dll</HintPath>

--- a/src/CommonLibrariesForNET/packages.config
+++ b/src/CommonLibrariesForNET/packages.config
@@ -5,5 +5,5 @@
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="portable-net45+win8+wp8" />
   <package id="Microsoft.Bcl.Compression" version="3.9.85" targetFramework="portable-net45+win+wp8" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="portable-net45+win8+wp8" />
-  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="portable45-net45+win8+wp8" />
+  <package id="Newtonsoft.Json" version="8.0.1" targetFramework="portable-net45+win+wp80" />
 </packages>

--- a/src/ForceToolkitForNET.FunctionalTests/ForceToolkitForNET.FunctionalTests.csproj
+++ b/src/ForceToolkitForNET.FunctionalTests/ForceToolkitForNET.FunctionalTests.csproj
@@ -47,8 +47,8 @@
       <HintPath>..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.Desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.8.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework">

--- a/src/ForceToolkitForNET.FunctionalTests/packages.config
+++ b/src/ForceToolkitForNET.FunctionalTests/packages.config
@@ -5,7 +5,7 @@
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net45" />
   <package id="Microsoft.Bcl.Compression" version="3.9.85" targetFramework="net45" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="8.0.1" targetFramework="net45" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
   <package id="WadeWegner.Salesforce.SOAPHelpers" version="0.0.3" targetFramework="net45" />
 </packages>

--- a/src/ForceToolkitForNET.UnitTests/ForceToolkitForNET.UnitTests.csproj
+++ b/src/ForceToolkitForNET.UnitTests/ForceToolkitForNET.UnitTests.csproj
@@ -47,8 +47,8 @@
       <HintPath>..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.Desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.8.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework">

--- a/src/ForceToolkitForNET.UnitTests/packages.config
+++ b/src/ForceToolkitForNET.UnitTests/packages.config
@@ -4,6 +4,6 @@
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net45" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net45" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="8.0.1" targetFramework="net45" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
 </packages>

--- a/src/ForceToolkitForNET/ForceToolkitForNET.csproj
+++ b/src/ForceToolkitForNET/ForceToolkitForNET.csproj
@@ -58,8 +58,9 @@
     <Reference Include="Microsoft.Threading.Tasks.Extensions">
       <HintPath>..\packages\Microsoft.Bcl.Async.1.0.168\lib\portable-net45+win8+wp8+wpa81\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\portable-net40+sl5+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.8.0.1\lib\portable-net45+wp80+win8+wpa81+dnxcore50\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.IO.Compression">
       <HintPath>..\packages\Microsoft.Bcl.Compression.3.9.85\lib\portable-net45+win8+wp8+wpa81\System.IO.Compression.dll</HintPath>

--- a/src/ForceToolkitForNET/packages.config
+++ b/src/ForceToolkitForNET/packages.config
@@ -5,5 +5,5 @@
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="portable-net45+win8+wp8" />
   <package id="Microsoft.Bcl.Compression" version="3.9.85" targetFramework="portable-net45+win+wp8" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="portable-net45+win8+wp8" />
-  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="portable45-net45+win8+wp8" />
+  <package id="Newtonsoft.Json" version="8.0.1" targetFramework="portable-net45+win+wp80" />
 </packages>


### PR DESCRIPTION
We needed the latest version (8.0.1) of Newtonsoft.Json nuget to be referenced by Force.com-Toolkit-for-Net. I went through updated the package reference and compiled. It appears to work fine. I'm going through production testing now.

I thought I'd share the changes which were only the update to the reference. If it's useful for you, feel free to merge.