### PR TITLE
Update QueryResult.cs

### DIFF
--- a/src/CommonLibrariesForNET/Models/QueryResult.cs
+++ b/src/CommonLibrariesForNET/Models/QueryResult.cs
@@ -12,7 +12,7 @@ namespace Salesforce.Common.Models
         public int TotalSize { get; set; }
 
         [JsonProperty(PropertyName = "done")]
-        public string Done { get; set; }
+        public bool Done { get; set; }
 
         [JsonProperty(PropertyName = "records")]
         public List<T> Records { get; set; }


### PR DESCRIPTION
According to the API documentation (https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/quickstart_code.htm#get_soql_resource), the "done" field returns a boolean, not a string. This is causing the Json deserialization to fail.