### PR TITLE
Fixed potential crash during call to ServiceHttpClient.Dispose

### DIFF
--- a/src/CommonLibrariesForNET/IServiceHttpClient.cs
+++ b/src/CommonLibrariesForNET/IServiceHttpClient.cs
@@ -5,9 +5,8 @@ using Salesforce.Common.Models;
 
 namespace Salesforce.Common
 {
-    public interface IServiceHttpClient
+    public interface IServiceHttpClient : IDisposable
     {
-        void Dispose();
         Task<T> HttpGetAsync<T>(string urlSuffix);
         Task<T> HttpGetRestApiAsync<T>(string apiName);
         Task<IList<T>> HttpGetAsync<T>(string urlSuffix, string nodeName);

--- a/src/CommonLibrariesForNET/ServiceHttpClient.cs
+++ b/src/CommonLibrariesForNET/ServiceHttpClient.cs
@@ -12,7 +12,7 @@ using Salesforce.Common.Serializer;
 
 namespace Salesforce.Common
 {
-    public class ServiceHttpClient : IServiceHttpClient, IDisposable
+    public class ServiceHttpClient : IServiceHttpClient
     {
         private const string UserAgent = "forcedotcom-toolkit-dotnet";
         private const string DateFormat = "s";
@@ -48,7 +48,7 @@ namespace Salesforce.Common
 
         public void Dispose()
         {
-            if (_disposeHttpClient)
+            if (_disposeHttpClient && _httpClient != null)
             {
                 _httpClient.Dispose();
             }

--- a/src/ForceToolkitForNET/ForceClient.cs
+++ b/src/ForceToolkitForNET/ForceClient.cs
@@ -10,7 +10,7 @@ using Salesforce.Common.Models;
 
 namespace Salesforce.Force
 {
-    public class ForceClient : IForceClient, IDisposable
+    public class ForceClient : IForceClient
     {
         private readonly ServiceHttpClient _serviceHttpClient;
 

--- a/src/ForceToolkitForNET/IForceClient.cs
+++ b/src/ForceToolkitForNET/IForceClient.cs
@@ -5,7 +5,7 @@ using Salesforce.Common.Models;
 
 namespace Salesforce.Force
 {
-    public interface IForceClient
+    public interface IForceClient : IDisposable
     {
         Task<QueryResult<T>> QueryAsync<T>(string query);
         Task<QueryResult<T>> QueryContinuationAsync<T>(string nextRecordsUrl);
@@ -28,6 +28,5 @@ namespace Salesforce.Force
         Task<T> RecentAsync<T>(int limit = 200);
         Task<List<T>> SearchAsync<T>(string query);
         Task<T> UserInfo<T>(string url);
-        void Dispose();
     }
 }


### PR DESCRIPTION
Hi, in my code I create `ForceClient` with httpClient parameter to be null. When is it being disposed after leaving `using` block I got the below exception
![image](https://cloud.githubusercontent.com/assets/4508264/14334276/902df2ea-fc53-11e5-8446-815d27e7361e.png)
I myself have no explanation how this private field can be empty after assigning newly constructed value to it but this is a small fix that allows client not to throw exception in `Dispose()` method higher