### PR TITLE
Changed ForceClient._serviceHttpClient to protected

### DIFF
--- a/src/ForceToolkitForNET/ForceClient.cs
+++ b/src/ForceToolkitForNET/ForceClient.cs
@@ -12,7 +12,7 @@ namespace Salesforce.Force
 {
     public class ForceClient : IForceClient, IDisposable
     {
-        private readonly ServiceHttpClient _serviceHttpClient;
+        protected readonly ServiceHttpClient _serviceHttpClient;
 
         public ForceClient(string instanceUrl, string accessToken, string apiVersion, HttpClient httpClient = null)
         {


### PR DESCRIPTION
Issue #211 - Changed ForceClient._serviceHttpClient to protected so that the ForceClient class can be extended.
