### PR TITLE
Fixed errors on build and run.

### DIFF
--- a/samples/SimpleConsole/App.config
+++ b/samples/SimpleConsole/App.config
@@ -4,13 +4,13 @@
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
   </startup>
   <appSettings>
-    <add key="SecurityToken" value="6k3w6JJMXodrfHcWdueD1btJM" />
-    <add key="ConsumerKey" value="3MVG9JZ_r.QzrS7izXVWrETc3v0NfBxwFgCay87uv43B4MWDgRSVaTnGG.zn2r01Yk8tRk2ea5memOKg4hd22" />
-    <add key="ConsumerSecret" value="8439347496860439806" />
-    <add key="Username" value="api@dotnetbuild.com" />
-    <add key="Password" value="Pa$$w0rd!" />
+    <add key="ConsumerKey" value="[CONSUMER_KEY]" /> <!-- Setup -> Create -> Apps -> Connected Apps -> New -> Check 'Enable OAuth and set the OAuth Scope(s). Fill remaining required fields. -->
+    <add key="ConsumerSecret" value="[CONSUMER_SECRET]" /> <!-- Secret is generated along with the Consumer Key -->
+    <add key="SecurityToken" value="[SECURITY_TOKEN]" /> <!-- My Settings -> Personal -> Reset My Security Token  -->
+    <add key="Username" value="[USERNAME]" /> <!-- My Settings -> Personal -> Personal Information  -->
+    <add key="Password" value="[PASSWORD]" /> <!-- My Settings -> Personal -> Change My Password  -->
 
-    <!--set to true to point  SimpleConsole at a Sandbox environment-->
+    <!--set to true to point  SimpleConsole at a Sandbox environment (test.salesforce.com) -->
     <add key="IsSandboxUser" value="false" />
   </appSettings>
   <runtime>

--- a/samples/SimpleConsole/Program.cs
+++ b/samples/SimpleConsole/Program.cs
@@ -6,6 +6,7 @@ using Salesforce.Common;
 using Salesforce.Force;
 using System.Threading.Tasks;
 using System.Dynamic;
+using System.Net;
 
 namespace SimpleConsole
 {
@@ -20,6 +21,8 @@ namespace SimpleConsole
 
         static void Main()
         {
+            System.Net.ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+
             try
             {
                 var task = RunSample();
@@ -38,6 +41,8 @@ namespace SimpleConsole
 
                     innerException = innerException.InnerException;
                 }
+
+                Console.ReadLine(); // Prevent the app from closing so the error can be seen
             }
         }
 
@@ -91,7 +96,8 @@ namespace SimpleConsole
             // Create a sample record
             Console.WriteLine("Creating test record.");
             var account = new Account { Name = "Test Account" };
-            account.Id = await client.CreateAsync(Account.SObjectTypeName, account);
+            var createAccountResponse = await client.CreateAsync(Account.SObjectTypeName, account);
+            account.Id = createAccountResponse.Id;
             if (account.Id == null)
             {
                 Console.WriteLine("Failed to create test record.");
@@ -158,7 +164,8 @@ namespace SimpleConsole
             Console.WriteLine("Creating a parent record (Account)");
             dynamic a = new ExpandoObject();
             a.Name = "Account from .Net Toolkit";
-            a.Id = await client.CreateAsync("Account", a);
+            var createParentAccountResponse = await client.CreateAsync("Account", a);
+            a.Id = createParentAccountResponse.Id;
             if (a.Id == null)
             {
                 Console.WriteLine("Failed to create parent record.");
@@ -170,7 +177,8 @@ namespace SimpleConsole
             c.FirstName = "Joe";
             c.LastName = "Blow";
             c.AccountId = a.Id;
-            c.Id = await client.CreateAsync("Contact", c);
+            var createContactResponse = await client.CreateAsync("Contact", c);
+            c.Id = createContactResponse.Id;
             if (c.Id == null)
             {
                 Console.WriteLine("Failed to create child record.");

--- a/samples/SimpleConsole/SimpleConsole.csproj
+++ b/samples/SimpleConsole/SimpleConsole.csproj
@@ -44,9 +44,9 @@
     <Reference Include="Microsoft.Threading.Tasks.Extensions.Desktop">
       <HintPath>..\..\src\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.Desktop.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
@@ -89,12 +89,6 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <Import Project="..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))" />
-  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/samples/SimpleConsole/packages.config
+++ b/samples/SimpleConsole/packages.config
@@ -4,5 +4,5 @@
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net45" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net45" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Brought up code to a working state. TLS 1.1 or higher is now required by Salesforce - forcing TLS 1.2. Updated NewtonSoft to the highest working version (8.0.3). Updated app.config with comments on where to find required values instead of including values which don't work.