### PR TITLE
Place assemblies in PCL framework folder

### DIFF
--- a/scripts/assets/ChatterToolkitForNET.Symbol.nuspec
+++ b/scripts/assets/ChatterToolkitForNET.Symbol.nuspec
@@ -19,10 +19,10 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="..\..\src\ChatterToolkitForNET\bin\Debug\Salesforce.Chatter.dll" target="lib" />
-    <file src="..\..\src\ChatterToolkitForNET\bin\Debug\Salesforce.Chatter.pdb" target="lib" />
-    <file src="..\..\src\CommonLibrariesForNET\bin\Debug\Salesforce.Common.dll" target="lib" />
-    <file src="..\..\src\CommonLibrariesForNET\bin\Debug\Salesforce.Common.pdb" target="lib" />
+    <file src="..\..\src\ChatterToolkitForNET\bin\Debug\Salesforce.Chatter.dll" target="lib\portable-net45+win8\Salesforce.Chatter.dll" />
+    <file src="..\..\src\ChatterToolkitForNET\bin\Debug\Salesforce.Chatter.pdb" target="lib\portable-net45+win8\Salesforce.Chatter.pdb" />
+    <file src="..\..\src\CommonLibrariesForNET\bin\Debug\Salesforce.Common.dll" target="lib\portable-net45+win8\Salesforce.Common.dll" />
+    <file src="..\..\src\CommonLibrariesForNET\bin\Debug\Salesforce.Common.pdb" target="lib\portable-net45+win8\Salesforce.Commom.pdb" />
     <file src="..\..\src\ChatterToolkitForNET\*.cs" target="src" />
     <file src="..\..\src\ChatterToolkitForNET\Models\*.cs" target="src" />
     <file src="..\..\src\CommonLibrariesForNET\*.cs" target="src" />

--- a/scripts/assets/ChatterToolkitForNET.nuspec
+++ b/scripts/assets/ChatterToolkitForNET.nuspec
@@ -19,8 +19,8 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="..\..\src\ChatterToolkitForNET\bin\Release\Salesforce.Chatter.dll" target="lib" />
-    <file src="..\..\src\CommonLibrariesForNET\bin\Release\Salesforce.Common.dll" target="lib" />
+    <file src="..\..\src\ChatterToolkitForNET\bin\Release\Salesforce.Chatter.dll" target="lib\portable-net45+win8\Salesforce.Chatter.dll" />
+    <file src="..\..\src\CommonLibrariesForNET\bin\Release\Salesforce.Common.dll" target="lib\portable-net45+win8\Salesforce.Common.dll" />
     <file src="..\..\src\ChatterToolkitForNET\tools\Install.ps1" target="tools" />
   </files>
 </package>

--- a/scripts/assets/ForceToolkitForNET.Symbol.nuspec
+++ b/scripts/assets/ForceToolkitForNET.Symbol.nuspec
@@ -19,10 +19,10 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="..\..\src\ForceToolkitForNET\bin\Debug\Salesforce.Force.dll" target="lib" />
-    <file src="..\..\src\ForceToolkitForNET\bin\Debug\Salesforce.Force.pdb" target="lib" />
-    <file src="..\..\src\CommonLibrariesForNET\bin\Debug\Salesforce.Common.dll" target="lib" />
-    <file src="..\..\src\CommonLibrariesForNET\bin\Debug\Salesforce.Common.pdb" target="lib" />
+    <file src="..\..\src\ForceToolkitForNET\bin\Debug\Salesforce.Force.dll" target="lib\portable-net45+win8\Salesforce.Force.dll" />
+    <file src="..\..\src\ForceToolkitForNET\bin\Debug\Salesforce.Force.pdb" target="lib\portable-net45+win8\Salesforce.Force.pdb" />
+    <file src="..\..\src\CommonLibrariesForNET\bin\Debug\Salesforce.Common.dll" target="lib\portable-net45+win8\Salesforce.Common.dll" />
+    <file src="..\..\src\CommonLibrariesForNET\bin\Debug\Salesforce.Common.pdb" target="lib\portable-net45+win8\Salesforce.Common.pdb" />
     <file src="..\..\src\ForceToolkitForNET\*.cs" target="src" />
     <file src="..\..\src\CommonLibrariesForNET\*.cs" target="src" />
     <file src="..\..\src\CommonLibrariesForNET\Models\*.cs" target="src" />

--- a/scripts/assets/ForceToolkitForNET.nuspec
+++ b/scripts/assets/ForceToolkitForNET.nuspec
@@ -19,8 +19,8 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="..\..\src\ForceToolkitForNET\bin\Release\Salesforce.Force.dll" target="lib" />
-    <file src="..\..\src\CommonLibrariesForNET\bin\Release\Salesforce.Common.dll" target="lib" />
+    <file src="..\..\src\ForceToolkitForNET\bin\Release\Salesforce.Force.dll" target="lib\portable-net45+win8\Salesforce.Force.dll" />
+    <file src="..\..\src\CommonLibrariesForNET\bin\Release\Salesforce.Common.dll" target="lib\portable-net45+win8\Salesforce.Common.dll" />
     <file src="..\..\src\ForceToolkitForNET\tools\Install.ps1" target="tools" />
   </files>
 </package>


### PR DESCRIPTION
These changes will allow .NET Core apps to use these libraries as requested in https://github.com/developerforce/Force.com-Toolkit-for-NET/issues/196.

The following import section will be needed in project.json of the client application:

```
"frameworks": {
  "netcoreapp1.1": {
    "dependencies": {
      "Microsoft.NETCore.App": {
        "version": "1.1.0",
        "type": "platform"
      }
    },
    "imports": [ "dotnet5.6", "portable-net45+win8" ]
  }
}
```