### PR TITLE
RunJobAndPollAsync performance improvement

### DIFF
--- a/src/ForceToolkitForNET/IForceClient.cs
+++ b/src/ForceToolkitForNET/IForceClient.cs
@@ -33,7 +33,7 @@ namespace Salesforce.Force
         Task<T> UserInfo<T>(string url);
 
         // BULK
-        Task<List<BatchInfoResult>> RunJobAsync<T>(string objectName, BulkConstants.OperationType operationType, IEnumerable<ISObjectList<T>> recordsLists);
+        Task<Queue<BatchInfoResult>> RunJobAsync<T>(string objectName, BulkConstants.OperationType operationType, IEnumerable<ISObjectList<T>> recordsLists);
         Task<List<BatchResultList>> RunJobAndPollAsync<T>(string objectName, BulkConstants.OperationType operationType, IEnumerable<ISObjectList<T>> recordsLists);
         Task<JobInfoResult> CreateJobAsync(string objectName, BulkConstants.OperationType operationType);
         Task<BatchInfoResult> CreateJobBatchAsync<T>(JobInfoResult jobInfo, ISObjectList<T> recordsObject);


### PR DESCRIPTION
Simplified the code using a Queue runs faster when you post large jobs and consumes less memory. Not drastically differences but you can notice when you have big loads.