### PR TITLE
Added ability to specify whether null properties should serialise for...

### DIFF
--- a/src/CommonLibrariesForNET/IJsonHttpClient.cs
+++ b/src/CommonLibrariesForNET/IJsonHttpClient.cs
@@ -21,8 +21,8 @@ namespace Salesforce.Common
         Task<T> HttpBinaryDataPostAsync<T>(string urlSuffix, object inputObject, byte[] fileContents, string headerName, string fileName);
 
         // PATCH
-        Task<SuccessResponse> HttpPatchAsync(object inputObject, string urlSuffix);
-        Task<SuccessResponse> HttpPatchAsync(object inputObject, Uri uri);
+        Task<SuccessResponse> HttpPatchAsync(object inputObject, string urlSuffix, bool shouldSerializeNulls = false);
+        Task<SuccessResponse> HttpPatchAsync(object inputObject, Uri uri, bool shouldSerializeNulls = false);
 
         // DELETE
         Task<bool> HttpDeleteAsync(string urlSuffix);

--- a/src/CommonLibrariesForNET/JsonHttpClient.cs
+++ b/src/CommonLibrariesForNET/JsonHttpClient.cs
@@ -174,19 +174,19 @@ namespace Salesforce.Common
 
         // PATCH
 
-        public async Task<SuccessResponse> HttpPatchAsync(object inputObject, string urlSuffix)
+        public async Task<SuccessResponse> HttpPatchAsync(object inputObject, string urlSuffix, bool shouldSerializeNulls = false)
         {
             var url = Common.FormatUrl(urlSuffix, InstanceUrl, ApiVersion);
-            return await HttpPatchAsync(inputObject, url);
+            return await HttpPatchAsync(inputObject, url, shouldSerializeNulls);
         }
 
-        public async Task<SuccessResponse> HttpPatchAsync(object inputObject, Uri uri)
+        public async Task<SuccessResponse> HttpPatchAsync(object inputObject, Uri uri, bool shouldSerializeNulls = false)
         {
             var json = JsonConvert.SerializeObject(inputObject,
                 Formatting.None,
                 new JsonSerializerSettings
                 {
-                    NullValueHandling = NullValueHandling.Ignore,
+                    NullValueHandling = shouldSerializeNulls ? NullValueHandling.Include : NullValueHandling.Ignore,
                     ContractResolver = new UpdateableContractResolver(),
                     DateFormatString = DateFormat
                 });

--- a/src/ForceToolkitForNET/ForceClient.cs
+++ b/src/ForceToolkitForNET/ForceClient.cs
@@ -98,23 +98,23 @@ namespace Salesforce.Force
             return await _jsonHttpClient.HttpPostAsync<SuccessResponse>(record, string.Format("sobjects/{0}", objectName)).ConfigureAwait(false);
         }
 
-        public Task<SuccessResponse> UpdateAsync(string objectName, string recordId, object record)
+        public Task<SuccessResponse> UpdateAsync(string objectName, string recordId, object record, bool shouldSerializeNulls = false)
         {
             if (string.IsNullOrEmpty(objectName)) throw new ArgumentNullException("objectName");
             if (string.IsNullOrEmpty(recordId)) throw new ArgumentNullException("recordId");
             if (record == null) throw new ArgumentNullException("record");
 
-            return _jsonHttpClient.HttpPatchAsync(record, string.Format("sobjects/{0}/{1}", objectName, recordId));
+            return _jsonHttpClient.HttpPatchAsync(record, string.Format("sobjects/{0}/{1}", objectName, recordId), shouldSerializeNulls);
         }
 
-        public Task<SuccessResponse> UpsertExternalAsync(string objectName, string externalFieldName, string externalId, object record)
+        public Task<SuccessResponse> UpsertExternalAsync(string objectName, string externalFieldName, string externalId, object record, bool shouldSerializeNulls = false)
         {
             if (string.IsNullOrEmpty(objectName)) throw new ArgumentNullException("objectName");
             if (string.IsNullOrEmpty(externalFieldName)) throw new ArgumentNullException("externalFieldName");
             if (string.IsNullOrEmpty(externalId)) throw new ArgumentNullException("externalId");
             if (record == null) throw new ArgumentNullException("record");
 
-            return _jsonHttpClient.HttpPatchAsync(record, string.Format("sobjects/{0}/{1}/{2}", objectName, externalFieldName, externalId));
+            return _jsonHttpClient.HttpPatchAsync(record, string.Format("sobjects/{0}/{1}/{2}", objectName, externalFieldName, externalId), shouldSerializeNulls);
         }
 
         public Task<bool> DeleteAsync(string objectName, string recordId)

--- a/src/ForceToolkitForNET/IForceClient.cs
+++ b/src/ForceToolkitForNET/IForceClient.cs
@@ -17,8 +17,8 @@ namespace Salesforce.Force
         Task<T> ExecuteRestApiAsync<T>(string apiName);
         Task<T> ExecuteRestApiAsync<T>(string apiName, object inputObject);
         Task<SuccessResponse> CreateAsync(string objectName, object record);
-        Task<SuccessResponse> UpdateAsync(string objectName, string recordId, object record);
-        Task<SuccessResponse> UpsertExternalAsync(string objectName, string externalFieldName, string externalId, object record);
+        Task<SuccessResponse> UpdateAsync(string objectName, string recordId, object record, bool shouldSerializeNulls = false);
+        Task<SuccessResponse> UpsertExternalAsync(string objectName, string externalFieldName, string externalId, object record, bool shouldSerializeNulls = false);
         Task<bool> DeleteAsync(string objectName, string recordId);
         Task<bool> DeleteExternalAsync(string objectName, string externalFieldName, string externalId);
         Task<DescribeGlobalResult<T>> GetObjectsAsync<T>();


### PR DESCRIPTION
… ForceClient update and upsert operations

HttpPatchAsync used NullValueHandling.Ignore for json serialization to allow for partial updates. As a side effect, this removed the ability to clear out fields in Salesforce. 

This change allows the user to specify whether null properties should serialize.
Specific properties can be ignored using [JsonIgnore]