### PR TITLE
QueryAllFieldsByIdAsync and GetFieldsCommaSeparatedListAsync methods to allow dynamic queries

### DIFF
--- a/azure-devops-ci.yml
+++ b/azure-devops-ci.yml
@@ -1,0 +1,2 @@
+ steps:
+ - script: echo hello world

--- a/src/ForceToolkitForNET/ForceClient.cs
+++ b/src/ForceToolkitForNET/ForceClient.cs
@@ -114,6 +114,19 @@ namespace Salesforce.Force
             return results.Records.FirstOrDefault();
         }
 
+        public async Task<T> QueryAllFieldsByExternalIdAsync<T>(string objectName, string externalIdFieldName, string externalId)
+        {
+            if (string.IsNullOrEmpty(objectName)) throw new ArgumentNullException("objectName");
+            if (string.IsNullOrEmpty(externalIdFieldName)) throw new ArgumentNullException("externalIdFieldName");
+            if (string.IsNullOrEmpty(externalId)) throw new ArgumentNullException("externalId");
+
+            var fields = await GetFieldsCommaSeparatedListAsync(objectName);
+            var query = string.Format("SELECT {0} FROM {1} WHERE {2} = '{3}'", fields, objectName, externalIdFieldName, externalId);
+            var results = await QueryAsync<T>(query).ConfigureAwait(false);
+
+            return results.Records.FirstOrDefault();
+        }
+
         public async Task<SuccessResponse> CreateAsync(string objectName, object record)
         {
             if (string.IsNullOrEmpty(objectName)) throw new ArgumentNullException("objectName");

--- a/src/ForceToolkitForNET/ForceClient.cs
+++ b/src/ForceToolkitForNET/ForceClient.cs
@@ -10,6 +10,8 @@ using Salesforce.Common.Models;
 using Salesforce.Common.Soql;
 using Salesforce.Common.Models.Json;
 using Salesforce.Common.Models.Xml;
+using System.Dynamic;
+using System.Collections;
 
 namespace Salesforce.Force
 {
@@ -18,7 +20,7 @@ namespace Salesforce.Force
         protected readonly XmlHttpClient _xmlHttpClient;
         protected readonly JsonHttpClient _jsonHttpClient;
 
-	      public ISelectListResolver SelectListResolver { get; set; }
+        public ISelectListResolver SelectListResolver { get; set; }
 
         public ForceClient(string instanceUrl, string accessToken, string apiVersion)
             : this(instanceUrl, accessToken, apiVersion, new HttpClient(), new HttpClient())
@@ -35,7 +37,7 @@ namespace Salesforce.Force
 
             _jsonHttpClient = new JsonHttpClient(instanceUrl, apiVersion, accessToken, httpClientForJson);
             _xmlHttpClient = new XmlHttpClient(instanceUrl, apiVersion, accessToken, httpClientForXml);
-            
+
             SelectListResolver = new DataMemberSelectListResolver();
         }
 
@@ -94,6 +96,18 @@ namespace Salesforce.Force
             if (string.IsNullOrEmpty(recordId)) throw new ArgumentNullException("recordId");
 
             var fields = SelectListResolver.GetFieldsList<T>();
+            var query = string.Format("SELECT {0} FROM {1} WHERE Id = '{2}'", fields, objectName, recordId);
+            var results = await QueryAsync<T>(query).ConfigureAwait(false);
+
+            return results.Records.FirstOrDefault();
+        }
+
+        public async Task<T> QueryAllFieldsByIdAsync<T>(string objectName, string recordId)
+        {
+            if (string.IsNullOrEmpty(objectName)) throw new ArgumentNullException("objectName");
+            if (string.IsNullOrEmpty(recordId)) throw new ArgumentNullException("recordId");
+
+            var fields = await GetFieldsCommaSeparatedListAsync(objectName);
             var query = string.Format("SELECT {0} FROM {1} WHERE Id = '{2}'", fields, objectName, recordId);
             var results = await QueryAsync<T>(query).ConfigureAwait(false);
 
@@ -236,6 +250,18 @@ namespace Salesforce.Force
 
             var response = await _jsonHttpClient.HttpGetAsync<T>(new Uri(url));
             return response;
+        }
+
+        public async Task<string> GetFieldsCommaSeparatedListAsync(string objectName)
+        {
+            IDictionary<string, object> objectProperties = await DescribeAsync<ExpandoObject>(objectName);
+            objectProperties.TryGetValue("fields", out object fields);
+            List<string> objectDescription = new List<string>();
+            foreach (ExpandoObject field in fields as IEnumerable)
+            {
+                objectDescription.Add((field).FirstOrDefault(x => x.Key == "name").Value.ToString());                
+            }
+            return string.Join(", ", objectDescription);
         }
 
         // BULK METHODS

--- a/src/ForceToolkitForNET/ForceToolkitForNET.csproj
+++ b/src/ForceToolkitForNET/ForceToolkitForNET.csproj
@@ -51,6 +51,7 @@
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\ForceTookitForNet.snk</AssemblyOriginatorKeyFile>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\CommonLibrariesForNET\CommonLibrariesForNET.csproj" PrivateAssets="All" />
@@ -60,7 +61,7 @@
   </ItemGroup>
   <Target Name="IncludeSalesforceCommon">
     <ItemGroup>
-      <BuildOutputInPackage Include="$(OutputPath)\Salesforce.Common.dll" />
+      <BuildOutputInPackage Include="$(OutputPath)Salesforce.Common.dll" />
     </ItemGroup>
   </Target>
 </Project>

--- a/src/ForceToolkitForNET/IForceClient.cs
+++ b/src/ForceToolkitForNET/IForceClient.cs
@@ -15,6 +15,7 @@ namespace Salesforce.Force
         Task<QueryResult<T>> QueryAllAsync<T>(string query);
         Task<T> QueryByIdAsync<T>(string objectName, string recordId);
         Task<T> QueryAllFieldsByIdAsync<T>(string objectName, string recordId);
+        Task<T> QueryAllFieldsByExternalIdAsync<T>(string objectName, string externalIdFieldName, string externalId);        
         Task<T> ExecuteRestApiAsync<T>(string apiName);
         Task<T> ExecuteRestApiAsync<T>(string apiName, object inputObject);
         Task<SuccessResponse> CreateAsync(string objectName, object record);

--- a/src/ForceToolkitForNET/IForceClient.cs
+++ b/src/ForceToolkitForNET/IForceClient.cs
@@ -14,6 +14,7 @@ namespace Salesforce.Force
         Task<QueryResult<T>> QueryContinuationAsync<T>(string nextRecordsUrl);
         Task<QueryResult<T>> QueryAllAsync<T>(string query);
         Task<T> QueryByIdAsync<T>(string objectName, string recordId);
+        Task<T> QueryAllFieldsByIdAsync<T>(string objectName, string recordId);
         Task<T> ExecuteRestApiAsync<T>(string apiName);
         Task<T> ExecuteRestApiAsync<T>(string apiName, object inputObject);
         Task<SuccessResponse> CreateAsync(string objectName, object record);
@@ -33,6 +34,7 @@ namespace Salesforce.Force
         Task<T> RecentAsync<T>(int limit = 200);
         Task<List<T>> SearchAsync<T>(string query);
         Task<T> UserInfo<T>(string url);
+        Task<string> GetFieldsCommaSeparatedListAsync(string objectName);
 
         // BULK
         Task<List<BatchInfoResult>> RunJobAsync<T>(string objectName, BulkConstants.OperationType operationType, IEnumerable<ISObjectList<T>> recordsLists);

--- a/tests/ForceToolkitForNET.Tests/ForceClientFunctionalTests.cs
+++ b/tests/ForceToolkitForNET.Tests/ForceClientFunctionalTests.cs
@@ -368,7 +368,25 @@ namespace Salesforce.Force.Tests
       Assert.True(result.Name == newName);
     }
 
-    [Test]
+        [Test]
+        public async Task Update_Account_ExternalIdChanged()
+        {
+            string originalExternalId = string.Concat(Guid.NewGuid().ToString("N").Take(16)); 
+            string newExternalId = string.Concat(Guid.NewGuid().ToString("N").Take(16));
+
+            dynamic account = new ExpandoObject();
+            account.Name = "New Account";
+            account.Description = "New Account Description";
+            account.ExternalId__c = originalExternalId;
+            var successResponse = await _client.CreateAsync("Account", account);
+            account.ExternalId__c = newExternalId;
+            await _client.UpdateAsync("Account", successResponse.Id, account);
+            dynamic result = await _client.QueryAllFieldsByIdAsync<ExpandoObject>("Account", successResponse.Id);
+            ((IDictionary<string, object>)result).TryGetValue("ExternalID__c", out object externalId);
+            Assert.True(externalId.ToString() == newExternalId);
+        }
+
+        [Test]
     public async Task Delete_Account_IsSuccess()
     {
       var account = new Account { Name = "New Account", Description = "New Account Description" };


### PR DESCRIPTION
This pull request adds two methods and one test with the intention of allowing all fields on a given object to be queried dynamically based on information returned from the "DescribeAsync" method rather than needing to create and pass in a proxy object. The main advantage of this is that fields can be added to the Salesforce object and picked up by the calling .NET application with minimal code changes. 

- GetFieldsCommaSeparatedListAsync - returns a comma separated list of all fields for a given object. This method calls "DescribeAsync" to retrieve the object properties into an ExpandoObject then iterates through the items in the "fields" property building a list of string values containing each field name.

- QueryAllFieldsByIdAsync - Similar to "QueryByIdAsync" but whereas QueryByIdAsync retrieves the fields that are available on a proxy class passed into the method as a type parameter via "SelectListResolver", "QueryAllFieldsByIdAsync" calls "GetFieldsCommaSeparatedListAsync" to build up a complete list of whatever fields are present on the object in the Salesforce instance.

Plus new test method Update_Account_ExternalIdChanged - populates a dynamic "Account" object with a name, description and a random ID in the custom ExternalID__c field, updates ExternalID__c with a new random ID, queries to retrieve all object fields and asserts the ExternalID__c field has been changed.