### PR TITLE
Added support for anonymous Apex execution

### DIFF
--- a/src/CommonLibrariesForNET/Models/Json/AnonymousExecutionResponse.cs
+++ b/src/CommonLibrariesForNET/Models/Json/AnonymousExecutionResponse.cs
@@ -1,0 +1,24 @@
+﻿using Newtonsoft.Json;
+
+namespace Salesforce.Common.Models.Json
+{
+    public class AnonymousExecutionResponse
+    {
+        [JsonProperty(PropertyName = "line")]
+        public int Line { get; set; }
+        [JsonProperty(PropertyName = "column")]
+        public int Column { get; set; }
+        [JsonProperty(PropertyName = "compiled")]
+        public bool Compiled { get; set; }
+        [JsonProperty(PropertyName = "success")]
+        public bool Success { get; set; }
+        [JsonProperty(PropertyName = "exceptionStackTrace")]
+        public string ExceptionStackTrace { get; set; }
+        [JsonProperty(PropertyName = "exceptionMessage")]
+        public string ExceptionMessage { get; set; }
+        [JsonProperty(PropertyName = "compileProblem")]
+        public string CompileProblem { get; set; }
+
+    }
+}
+

--- a/src/ForceToolkitForNET/ForceClient.cs
+++ b/src/ForceToolkitForNET/ForceClient.cs
@@ -238,6 +238,12 @@ namespace Salesforce.Force
             return response;
         }
 
+        public Task<T> ExecuteAnonymousAsync<T>(string apex)
+        {
+            if (string.IsNullOrEmpty(apex)) throw new ArgumentNullException("apex");
+            return _jsonHttpClient.HttpGetAsync<T>(string.Format("tooling/executeAnonymous/?anonymousBody={0}", Uri.EscapeDataString(apex)));
+        }
+
         // BULK METHODS
 
         public async Task<List<BatchInfoResult>> RunJobAsync<T>(string objectName, BulkConstants.OperationType operationType,

--- a/src/ForceToolkitForNET/IForceClient.cs
+++ b/src/ForceToolkitForNET/IForceClient.cs
@@ -33,6 +33,7 @@ namespace Salesforce.Force
         Task<T> RecentAsync<T>(int limit = 200);
         Task<List<T>> SearchAsync<T>(string query);
         Task<T> UserInfo<T>(string url);
+        Task<T> ExecuteAnonymousAsync<T>(string apex);
 
         // BULK
         Task<List<BatchInfoResult>> RunJobAsync<T>(string objectName, BulkConstants.OperationType operationType, IEnumerable<ISObjectList<T>> recordsLists);


### PR DESCRIPTION
Adding support for anonymous Apex execution as described on [documentation](https://developer.salesforce.com/docs/atlas.en-us.api_tooling.meta/api_tooling/intro_rest_resources.htm) 
