### PR TITLE
Adding apiVersion parameter to AuthenticationClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ var auth = new AuthenticationClient();
 await auth.UsernamePasswordAsync("YOURCONSUMERKEY", "YOURCONSUMERSECRET", "YOURUSERNAME", "YOURPASSWORD");
 ```
 
+You can also specify a SalesForce API version when creating an authentication client if your use case requires it. The default API Version is currently v36.0
+
+```cs
+var auth = new AuthenticationClient("v44.0");
+```
+
 #### Web-Server Authentication Flow
 
 The Web-Server Authentication Flow requires a few additional steps but has the advantage of allowing you to authenticate your users and let them interact with the Force.com using their own access token.

--- a/src/CommonLibrariesForNET/AuthenticationClient.cs
+++ b/src/CommonLibrariesForNET/AuthenticationClient.cs
@@ -19,17 +19,17 @@ namespace Salesforce.Common
         private const string TokenRequestEndpointUrl = "https://login.salesforce.com/services/oauth2/token";
         private readonly HttpClient _httpClient;
 
-        public AuthenticationClient()
-            : this(new HttpClient())
+        public AuthenticationClient(string apiVersion = "v36.0")
+            : this(new HttpClient(), apiVersion)
         {
         }
 
-        public AuthenticationClient(HttpClient httpClient)
+        public AuthenticationClient(HttpClient httpClient, string apiVersion)
         {
             if (httpClient == null) throw new ArgumentNullException("httpClient");
 
             _httpClient = httpClient;
-            ApiVersion = "v36.0";
+            ApiVersion = apiVersion;
         }
 
         public Task UsernamePasswordAsync(string clientId, string clientSecret, string username, string password)


### PR DESCRIPTION
Adding a way for users to specify a SalesForce API Version in authentication client if their use case requires it. 