### PR TITLE
Fixes #332 - Corrected XML attributes on ErrorResponse

### DIFF
--- a/src/CommonLibrariesForNET/Models/Json/ErrorResponse.cs
+++ b/src/CommonLibrariesForNET/Models/Json/ErrorResponse.cs
@@ -8,11 +8,11 @@ namespace Salesforce.Common.Models.Json
      IsNullable = false)]
     public class ErrorResponse
     {
-        [XmlElement(ElementName = "exceptionCode")]
+        [XmlElement(ElementName = "exceptionMessage")]
         [JsonProperty(PropertyName = "message")]
         public string Message;
 
-        [XmlElement(ElementName = "exceptionMessage")]
+        [XmlElement(ElementName = "exceptionCode")]
         [JsonProperty(PropertyName = "errorCode")]
         public string ErrorCode;
     }

--- a/tests/ForceToolkitForNET.Tests/CommonFunctionalTests.cs
+++ b/tests/ForceToolkitForNET.Tests/CommonFunctionalTests.cs
@@ -7,8 +7,8 @@ using System.Threading.Tasks;
 using NUnit.Framework;
 using Salesforce.Force.Tests.Models;
 using Salesforce.Common;
-using Salesforce.Common.Models;
 using Salesforce.Common.Models.Json;
+using Salesforce.Common.Models.Xml;
 
 namespace Salesforce.Force.Tests
 {
@@ -186,6 +186,32 @@ namespace Salesforce.Force.Tests
                 Assert.IsNotNull(ex);
                 Assert.IsNotNull(ex.Message);
                 Assert.That(ex.Message, Is.EqualTo("Session expired or invalid"));
+                Assert.IsNotNull(ex.Error);
+            }
+        }
+
+        [Test]
+        public async Task BadTokenHandlingWithXml()
+        {
+            var badToken = "badtoken";
+            var serviceHttpClient = new XmlHttpClient(_auth.InstanceUrl, _auth.ApiVersion, badToken, new HttpClient());
+
+            var jobInfo = new JobInfo
+            {
+                ContentType = "XML",
+                Object = "BadObject",
+                Operation = "BadOperation"
+            };
+
+            try
+            {
+                await serviceHttpClient.HttpPostAsync<JobInfoResult>(jobInfo, "/services/async/{0}/job");
+            }
+            catch (ForceException ex)
+            {
+                Assert.IsNotNull(ex);
+                Assert.IsNotNull(ex.Message);
+                Assert.That(ex.Message, Is.EqualTo("Invalid session id"));
                 Assert.IsNotNull(ex.Error);
             }
         }


### PR DESCRIPTION
This fixes #332 

Corrected issue with XML attributes on ErrorResponse object.

Added test in CommonFunctionalTests to verify going forward.