### PR TITLE
Fixes #331 - Added ExternalIdFieldName to JobInfo, and overloads to po…

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,13 @@ To access the Force.com APIs you must have a valid Access Token. Currently there
 
 #### Username-Password Authentication Flow
 
-The Username-Password Authentication Flow is a straightforward way to get an access token. Simply provide your consumer key, consumer secret, username, and password.
+The Username-Password Authentication Flow is a straightforward way to get an access token. Simply provide your consumer key, consumer secret, username, and password concatenated with your API Token.
 
 ```cs
 var auth = new AuthenticationClient();
 
-await auth.UsernamePasswordAsync("YOURCONSUMERKEY", "YOURCONSUMERSECRET", "YOURUSERNAME", "YOURPASSWORD");
+await auth.UsernamePasswordAsync("YOURCONSUMERKEY", "YOURCONSUMERSECRET", "YOURUSERNAME",
+                                 "YOURPASSWORDANDTOKEN");
 ```
 
 #### Web-Server Authentication Flow
@@ -67,7 +68,7 @@ await auth.WebServerAsync("YOURCONSUMERKEY", "YOURCONSUMERSECRET", "YOURCALLBACK
 
 You can see a demonstration of this in the following sample application: https://github.com/developerforce/Force.com-Toolkit-for-NET/tree/master/samples/WebServerOAuthFlow
 
-#### Creating the ForceClient or BulkForceClient
+#### Creating the ForceClient
 
 After this completes successfully you will receive a valid Access Token and Instance URL. The Instance URL returned identifies the web service URL you'll use to call the Force.com REST APIs, passing in the Access Token. Additionally, the authentication client will return the API version number, which is used to construct a valid HTTP request.
 
@@ -201,7 +202,7 @@ var accountsBatchList = new List<SObjectList<Account>>
 };
 
 var results = await bulkClient.RunJobAndPollAsync("Account",
-						Bulk.OperationType.Insert, accountsBatchList);
+						BulkConstants.OperationType.Insert, accountsBatchList);
 ```
 
 The above code will create 6 accounts in 3 batches. Each batch can hold upto 10,000 records and you can use multiple batches for Insert and all of the operations below.
@@ -228,12 +229,12 @@ var accountsBatchList = new List<SObjectList<SObject>>
 };
 
 var results = await bulkClient.RunJobAndPollAsync("Account",
-						Bulk.OperationType.Insert, accountsBatchList);
+                       BulkConstants.OperationType.Insert, accountsBatchList);
 ```
 
 #### Update
 
-Updating multiple records follows the same pattern as above, just change the `Bulk.OperationType` to `Bulk.OperationType.Update`
+Updating multiple records follows the same pattern as above, just change the `BulkConstants.OperationType` to `BulkConstants.OperationType.Update`
 
 ```cs
 var accountsBatch1 = new SObjectList<SObject>
@@ -256,12 +257,12 @@ var accountsBatchList = new List<SObjectList<SObject>>
 };
 
 var results = await bulkClient.RunJobAndPollAsync("Account",
-						Bulk.OperationType.Update, accountsBatchList);
+                       BulkConstants.OperationType.Update, accountsBatchList);
 ```
 
 #### Delete
 
-As above, you can delete multiple records with `Bulk.OperationType.Delete`
+As above, you can delete multiple records with `BulkConstants.OperationType.Delete`
 
 ```cs
 var accountsBatch1 = new SObjectList<SObject>
@@ -282,12 +283,44 @@ var accountsBatchList = new List<SObjectList<SObject>>
 };
 
 var results = await bulkClient.RunJobAndPollAsync("Account",
-						Bulk.OperationType.Delete, accountsBatchList);
+                       BulkConstants.OperationType.Delete, accountsBatchList);
+```
+
+#### Upsert
+
+If your object includes a custom field with the External Id property set, you can use that to perform bulk upsert (update or insert) actions with `BulkConstants.OperationType.Upsert`. Note that you also have to specify the External Id field name when starting the job.
+
+```cs
+// Assumes you have a custom field "ExampleId" on your Account object
+// that has the "External Id" flag set.
+
+var accountsBatch1 = new SObjectList<SObject>
+{
+	new SObject
+	{
+		{"Name" = "TestDyAccount1"},
+		{"ExampleId" = "ID00001"}
+	},
+	new SObject
+	{
+		{"Name" = "TestDyAccount2"},
+		{"ExampleId" = "ID00002"}
+	}
+};
+
+var accountsBatchList = new List<SObjectList<SObject>>
+{
+	accountsBatch1
+};
+
+var results = await bulkClient.RunJobAndPollAsync("Account", "ExampleId"
+                       BulkConstants.OperationType.Upsert, accountsBatchList);
+
 ```
 
 ## Contributing to the Repository
 
-If you find any issues or opportunities for improving this respository, fix them! Feel free to contribute to this project by [forking](http://help.github.com/fork-a-repo/) this repository and make changes to the content. Once you've made your changes, share them back with the community by sending a pull request. Please see [How to send pull requests](http://help.github.com/send-pull-requests/) for more information about contributing to Github projects.
+If you find any issues or opportunities for improving this repository, fix them! Feel free to contribute to this project by [forking](http://help.github.com/fork-a-repo/) this repository and make changes to the content. Once you've made your changes, share them back with the community by sending a pull request. Please see [How to send pull requests](http://help.github.com/send-pull-requests/) for more information about contributing to Github projects.
 
 ## Reporting Issues
 

--- a/src/CommonLibrariesForNET/Models/Xml/JobInfo.cs
+++ b/src/CommonLibrariesForNET/Models/Xml/JobInfo.cs
@@ -13,6 +13,12 @@ namespace Salesforce.Common.Models.Xml
         [XmlElement(ElementName = "object")]
         public string Object { get; set; }
 
+        [XmlElement(ElementName = "externalIdFieldName")]
+        public string ExternalIdFieldName { get; set; }
+
+        [XmlIgnore]
+        public bool ExternalIdFieldNameSpecified => !string.IsNullOrEmpty(ExternalIdFieldName);
+
         [XmlElement(ElementName = "contentType")]
         public string ContentType { get; set; }
 

--- a/src/ForceToolkitForNET/ForceClient.cs
+++ b/src/ForceToolkitForNET/ForceClient.cs
@@ -35,7 +35,7 @@ namespace Salesforce.Force
 
             _jsonHttpClient = new JsonHttpClient(instanceUrl, apiVersion, accessToken, httpClientForJson);
             _xmlHttpClient = new XmlHttpClient(instanceUrl, apiVersion, accessToken, httpClientForXml);
-            
+
             SelectListResolver = new DataMemberSelectListResolver();
         }
 
@@ -243,9 +243,17 @@ namespace Salesforce.Force
         public async Task<List<BatchInfoResult>> RunJobAsync<T>(string objectName, BulkConstants.OperationType operationType,
             IEnumerable<ISObjectList<T>> recordsLists)
         {
+            return await RunJobAsync(objectName, null, operationType, recordsLists);
+        }
+
+        public async Task<List<BatchInfoResult>> RunJobAsync<T>(string objectName, string externalIdFieldName,
+            BulkConstants.OperationType operationType, IEnumerable<ISObjectList<T>> recordsLists)
+        {
             if (recordsLists == null) throw new ArgumentNullException("recordsLists");
 
-            var jobInfoResult = await CreateJobAsync(objectName, operationType);
+            if (operationType == BulkConstants.OperationType.Upsert && string.IsNullOrEmpty(externalIdFieldName)) throw new ArgumentNullException(nameof(externalIdFieldName));
+
+            var jobInfoResult = await CreateJobAsync(objectName, externalIdFieldName, operationType);
             var batchResults = new List<BatchInfoResult>();
             foreach (var recordList in recordsLists)
             {
@@ -258,10 +266,16 @@ namespace Salesforce.Force
         public async Task<List<BatchResultList>> RunJobAndPollAsync<T>(string objectName, BulkConstants.OperationType operationType,
             IEnumerable<ISObjectList<T>> recordsLists)
         {
+            return await RunJobAndPollAsync(objectName, null, operationType, recordsLists);
+        }
+
+        public async Task<List<BatchResultList>> RunJobAndPollAsync<T>(string objectName, string externalIdFieldName, BulkConstants.OperationType operationType,
+            IEnumerable<ISObjectList<T>> recordsLists)
+        {
             const float pollingStart = 1000;
             const float pollingIncrease = 2.0f;
 
-            var batchInfoResults = await RunJobAsync(objectName, operationType, recordsLists);
+            var batchInfoResults = await RunJobAsync(objectName, externalIdFieldName, operationType, recordsLists);
 
             var currentPoll = pollingStart;
             var finishedBatchInfoResults = new List<BatchInfoResult>();
@@ -299,12 +313,18 @@ namespace Salesforce.Force
 
         public async Task<JobInfoResult> CreateJobAsync(string objectName, BulkConstants.OperationType operationType)
         {
-            if (string.IsNullOrEmpty(objectName)) throw new ArgumentNullException("objectName");
+            return await CreateJobAsync(objectName, null, operationType);
+        }
+
+        public async Task<JobInfoResult> CreateJobAsync(string objectName, string externalIdFieldName, BulkConstants.OperationType operationType)
+        {
+            if (string.IsNullOrEmpty(objectName)) throw new ArgumentNullException(nameof(objectName));
 
             var jobInfo = new JobInfo
             {
                 ContentType = "XML",
                 Object = objectName,
+                ExternalIdFieldName = externalIdFieldName,
                 Operation = operationType.Value()
             };
 

--- a/src/ForceToolkitForNET/ForceClient.cs
+++ b/src/ForceToolkitForNET/ForceClient.cs
@@ -320,6 +320,8 @@ namespace Salesforce.Force
         {
             if (string.IsNullOrEmpty(objectName)) throw new ArgumentNullException(nameof(objectName));
 
+            if (operationType == BulkConstants.OperationType.Upsert && string.IsNullOrEmpty(externalIdFieldName)) throw new ArgumentNullException(nameof(externalIdFieldName));
+
             var jobInfo = new JobInfo
             {
                 ContentType = "XML",

--- a/tests/ForceToolkitForNET.Tests/BulkForceClientFunctionalTests.cs
+++ b/tests/ForceToolkitForNET.Tests/BulkForceClientFunctionalTests.cs
@@ -19,6 +19,7 @@ namespace Salesforce.Force.Tests
         private static string _username = ConfigurationManager.AppSettings["Username"];
         private static string _password = ConfigurationManager.AppSettings["Password"];
         private static string _organizationId = ConfigurationManager.AppSettings["OrganizationId"];
+        private static bool _testUpsert;
 
         private AuthenticationClient _auth;
         private ForceClient _client;
@@ -26,6 +27,7 @@ namespace Salesforce.Force.Tests
         [OneTimeSetUp]
         public void Init()
         {
+            bool.TryParse(ConfigurationManager.AppSettings["TestUpsert"], out _testUpsert);
             if (string.IsNullOrEmpty(_consumerKey) && string.IsNullOrEmpty(_consumerSecret) && string.IsNullOrEmpty(_username) && string.IsNullOrEmpty(_password) && string.IsNullOrEmpty(_organizationId))
             {
                 _consumerKey = Environment.GetEnvironmentVariable("ConsumerKey");
@@ -33,6 +35,7 @@ namespace Salesforce.Force.Tests
                 _username = Environment.GetEnvironmentVariable("Username");
                 _password = Environment.GetEnvironmentVariable("Password");
                 _organizationId = Environment.GetEnvironmentVariable("OrganizationId");
+                bool.TryParse(Environment.GetEnvironmentVariable("TestUpsert"), out _testUpsert);
             }
 
             // Use TLS 1.2 (instead of defaulting to 1.0)
@@ -134,4 +137,63 @@ namespace Salesforce.Force.Tests
         }
     }
 
+        [Test]
+        public async Task UpsertTests()
+        {
+            // Requires a new field on Contact "Unique_Email__c" with External Id set.
+            if (_testUpsert)
+            {
+                var dtContactsBatch1 = new SObjectList<SObject>
+                {
+                    new SObject{{ "FirstName", "TestDtContact1"}, { "LastName", "TestDtContact1" }, { "MailingCity", "London" }, { "Email", "email1@example.com" }, {"Unique_Email__c", "email1@example.com"}},
+                    new SObject{{ "FirstName", "TestDtContact2"}, { "LastName", "TestDtContact2" }, { "MailingCity", "London" }, { "Email", "email2@example.com" }, {"Unique_Email__c", "email2@example.com" }}
+                };
+
+                var resultsUpsert1 = await _client.RunJobAndPollAsync("Contact", "Unique_Email__c",
+                    BulkConstants.OperationType.Upsert, new List<SObjectList<SObject>> { dtContactsBatch1 });
+
+                Assert.IsTrue(resultsUpsert1 != null);
+                Assert.AreEqual(resultsUpsert1.Count, 1);
+                Assert.AreEqual(resultsUpsert1[0].Items.Count, 2);
+                Assert.IsTrue(resultsUpsert1[0].Items[0].Created);
+                Assert.IsTrue(resultsUpsert1[0].Items[0].Success);
+                Assert.IsTrue(resultsUpsert1[0].Items[1].Created);
+                Assert.IsTrue(resultsUpsert1[0].Items[1].Success);
+
+                var dtContactsBatch2 = new SObjectList<SObject>
+                {
+                    new SObject{{ "FirstName", "TestDtContact2"}, { "LastName", "TestDtContact2" }, { "MailingCity", "York" }, { "Email", "email2@example.com" }, {"Unique_Email__c", "email2@example.com" }},
+                    new SObject{{ "FirstName", "TestDtContact3"}, { "LastName", "TestDtContact3" }, { "MailingCity", "York" }, { "Email", "email3@example.com" }, {"Unique_Email__c", "email3@example.com" }}
+                };
+
+                var resultsUpsert2 = await _client.RunJobAndPollAsync("Contact", "Unique_Email__c",
+                    BulkConstants.OperationType.Upsert, new List<SObjectList<SObject>> { dtContactsBatch2 });
+
+                Assert.IsTrue(resultsUpsert2 != null);
+                Assert.AreEqual(resultsUpsert2.Count, 1);
+                Assert.AreEqual(resultsUpsert2[0].Items.Count, 2);
+                Assert.IsFalse(resultsUpsert2[0].Items[0].Created);
+                Assert.IsTrue(resultsUpsert2[0].Items[0].Success);
+                Assert.IsTrue(resultsUpsert2[0].Items[1].Created);
+                Assert.IsTrue(resultsUpsert2[0].Items[1].Success);
+
+                // create an Id list for the original strongly typed accounts created
+                var idBatch = new SObjectList<SObject>();
+                idBatch.AddRange(resultsUpsert1[0].Items.Select(result => new SObject { { "Id", result.Id } }));
+                idBatch.Add(new SObject { {"Id", resultsUpsert2[0].Items[1].Id}});
+
+                var resultsDelete = await _client.RunJobAndPollAsync("Contact", BulkConstants.OperationType.Delete,
+                    new List<SObjectList<SObject>> { idBatch });
+
+                Assert.IsTrue(resultsDelete != null, "[results4] empty result object");
+                Assert.AreEqual(resultsDelete.Count, 1, "[results4] wrong number of results");
+                Assert.AreEqual(resultsDelete[0].Items.Count, 3, "[results4] wrong number of result records");
+            }
+            else
+            {
+                Assert.Inconclusive("Upsert Tests Skipped.");
+            }
+
+        }
+    }
 }

--- a/tests/ForceToolkitForNET.Tests/BulkForceClientFunctionalTests.cs
+++ b/tests/ForceToolkitForNET.Tests/BulkForceClientFunctionalTests.cs
@@ -135,7 +135,6 @@ namespace Salesforce.Force.Tests
             Assert.IsFalse(results4[0].Items[0].Created);
             Assert.IsTrue(results4[0].Items[0].Success);
         }
-    }
 
         [Test]
         public async Task UpsertTests()

--- a/tests/ForceToolkitForNET.Tests/BulkForceClientUnitTests.cs
+++ b/tests/ForceToolkitForNET.Tests/BulkForceClientUnitTests.cs
@@ -36,6 +36,16 @@ namespace Salesforce.Force.Tests
 
         [Test]
         [ExpectedException(typeof(ArgumentNullException))]
+        public async Task RunJobAndPoll_NullExternalIdOnUpsert_ArgumentNullException()
+        {
+            var client = new ForceClient("test", "test", "v32");
+            await client.RunJobAndPollAsync("Account", null, BulkConstants.OperationType.Upsert, new List<ISObjectList<SObject>>());
+
+            // expects exception
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentNullException))]
         public async Task RunJob_NullObjectName_ArgumentNullException()
         {
             var client = new ForceClient("test", "test", "v32");
@@ -63,6 +73,17 @@ namespace Salesforce.Force.Tests
 
             // expects exception
         }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public async Task CreateJobAsync_NullExternalIdOnUpsert_ArgumentNullException()
+        {
+            var client = new ForceClient("test", "test", "v32");
+            await client.CreateJobAsync("Account", null, BulkConstants.OperationType.Upsert);
+
+            // expects exception
+        }
+
 
         [Test]
         [ExpectedException(typeof(ArgumentNullException))]


### PR DESCRIPTION
This fixes #331

Added `ExternalIdFieldName` to the `JobInfo` class along with auto filling specified property to hide from XML if not required.

Added overloads to the `RunJobAsync`, `RunJobAsyncAndPollAsync` and `CreateJobAsync` methods on `ForceClient` to allow ExternalIdFieldName to be supplied, along with an argument check when operation type is Upsert.

Added optional test in `BulkForceClientFunctionalTests` to verify going forward - requires a new External Id field to be added to an object (I've added `Unique_Email__c` to `Contact` because that's where I needed it most, but happy to move it).