### PR TITLE
add GetBlobAsync to IForceClient interface

### DIFF
--- a/src/ForceToolkitForNET/IForceClient.cs
+++ b/src/ForceToolkitForNET/IForceClient.cs
@@ -33,6 +33,7 @@ namespace Salesforce.Force
         Task<T> RecentAsync<T>(int limit = 200);
         Task<List<T>> SearchAsync<T>(string query);
         Task<T> UserInfo<T>(string url);
+        Task<System.IO.Stream> GetBlobAsync(String objectName, String objectId, String fieldName);
 
         // BULK
         Task<List<BatchInfoResult>> RunJobAsync<T>(string objectName, BulkConstants.OperationType operationType, IEnumerable<ISObjectList<T>> recordsLists);


### PR DESCRIPTION
https://github.com/developerforce/Force.com-Toolkit-for-NET/pull/156 added the method to ForceClient but didn't update the IForceClient interface.  It would be preferable to be able to keep using the interface even when needing to call GetBlobAsync.

The signature being added matches the signature that was added in that pull request.  I think using 'recordId' for the second parameter name would be more consistent with the other calls but changing the parameter name is a breaking change so I'm just adding the signature as it already exists.