### PR TITLE
Fix for issue #354

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ TestResults
 *.user
 *.sln.docstates
 *.userprefs
+.vs/
 
 # Build results
 [Dd]ebug/

--- a/src/CommonLibrariesForNET/IJsonHttpClient.cs
+++ b/src/CommonLibrariesForNET/IJsonHttpClient.cs
@@ -11,15 +11,23 @@ namespace Salesforce.Common
 
         // GET
         Task<T> HttpGetAsync<T>(string urlSuffix);
+        Task<T> HttpGetAsync<T, TErrorResponse>(string urlSuffix) where TErrorResponse : IErrorResponse;
         Task<T> HttpGetAsync<T>(Uri uri);
+        Task<T> HttpGetAsync<T, TErrorResponse>(Uri uri) where TErrorResponse : IErrorResponse;
         Task<IList<T>> HttpGetAsync<T>(string urlSuffix, string nodeName);
+        Task<IList<T>> HttpGetAsync<T, TErrorResponse>(string urlSuffix, string nodeName) where TErrorResponse : IErrorResponse;
         Task<T> HttpGetRestApiAsync<T>(string apiName);
+        Task<T> HttpGetRestApiAsync<T, TErrorResponse>(string apiName) where TErrorResponse : IErrorResponse;
 
         // POST
         Task<T> HttpPostAsync<T>(object inputObject, string urlSuffix);
+        Task<T> HttpPostAsync<T, TErrorResponse>(object inputObject, string urlSuffix) where TErrorResponse : IErrorResponse;
         Task<T> HttpPostAsync<T>(object inputObject, Uri uri);
+        Task<T> HttpPostAsync<T, TErrorResponse>(object inputObject, Uri uri) where TErrorResponse : IErrorResponse;
         Task<T> HttpPostRestApiAsync<T>(string apiName, object inputObject);
+        Task<T> HttpPostRestApiAsync<T, TErrorResponse>(string apiName, object inputObject) where TErrorResponse : IErrorResponse;
         Task<T> HttpBinaryDataPostAsync<T>(string urlSuffix, object inputObject, byte[] fileContents, string headerName, string fileName);
+        Task<T> HttpBinaryDataPostAsync<T, TErrorResponse>(string urlSuffix, object inputObject, byte[] fileContents, string headerName, string fileName) where TErrorResponse : IErrorResponse;
 
         // PATCH
         Task<SuccessResponse> HttpPatchAsync(object inputObject, string urlSuffix);

--- a/src/CommonLibrariesForNET/Models/Json/ErrorResponses.cs
+++ b/src/CommonLibrariesForNET/Models/Json/ErrorResponses.cs
@@ -1,6 +1,14 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
+using System.Net;
 
 namespace Salesforce.Common.Models.Json
 {
-    public class ErrorResponses : List<ErrorResponse> { }
+    public class ErrorResponses : List<ErrorResponse>, IErrorResponse
+    {
+        public ForceException MapToForceException(HttpStatusCode status)
+        {
+            return new ForceException(this.FirstOrDefault()?.ErrorCode, this.FirstOrDefault()?.Message);
+        }
+    }
 }

--- a/src/CommonLibrariesForNET/Models/Json/IErrorResponse.cs
+++ b/src/CommonLibrariesForNET/Models/Json/IErrorResponse.cs
@@ -1,0 +1,9 @@
+﻿using System.Net;
+
+namespace Salesforce.Common.Models.Json 
+{
+    public interface IErrorResponse
+    {
+        ForceException MapToForceException(HttpStatusCode status);
+    }
+}

--- a/src/ForceToolkitForNET/ForceClient.cs
+++ b/src/ForceToolkitForNET/ForceClient.cs
@@ -80,6 +80,15 @@ namespace Salesforce.Force
             var response = await _jsonHttpClient.HttpGetRestApiAsync<T>(apiName);
             return response;
         }
+        
+        public async Task<T> ExecuteRestApiAsync<T, TErrorResponse>(string apiName)
+            where TErrorResponse : IErrorResponse
+        {
+            if (string.IsNullOrEmpty(apiName)) throw new ArgumentNullException("apiName");
+
+            var response = await _jsonHttpClient.HttpGetRestApiAsync<T, TErrorResponse>(apiName);
+            return response;
+        }
 
         public async Task<T> ExecuteRestApiAsync<T>(string apiName, object inputObject)
         {
@@ -87,6 +96,16 @@ namespace Salesforce.Force
             if (inputObject == null) throw new ArgumentNullException("inputObject");
 
             var response = await _jsonHttpClient.HttpPostRestApiAsync<T>(apiName, inputObject);
+            return response;
+        }
+
+        public async Task<T> ExecuteRestApiAsync<T, TErrorResponse>(string apiName, object inputObject)
+            where TErrorResponse : IErrorResponse
+        {
+            if (string.IsNullOrEmpty(apiName)) throw new ArgumentNullException("apiName");
+            if (inputObject == null) throw new ArgumentNullException("inputObject");
+
+            var response = await _jsonHttpClient.HttpPostRestApiAsync<T, TErrorResponse>(apiName, inputObject);
             return response;
         }
 

--- a/src/ForceToolkitForNET/IForceClient.cs
+++ b/src/ForceToolkitForNET/IForceClient.cs
@@ -17,7 +17,9 @@ namespace Salesforce.Force
         Task<T> QueryAllFieldsByIdAsync<T>(string objectName, string recordId);
         Task<T> QueryAllFieldsByExternalIdAsync<T>(string objectName, string externalIdFieldName, string externalId);        
         Task<T> ExecuteRestApiAsync<T>(string apiName);
+        Task<T> ExecuteRestApiAsync<T, TErrorResponse>(string apiName) where TErrorResponse : IErrorResponse;
         Task<T> ExecuteRestApiAsync<T>(string apiName, object inputObject);
+        Task<T> ExecuteRestApiAsync<T, TErrorResponse>(string apiName, object inputObject) where TErrorResponse : IErrorResponse;
         Task<SuccessResponse> CreateAsync(string objectName, object record);
         Task<SaveResponse> CreateAsync(string objectName, CreateRequest request);
         Task<SuccessResponse> UpdateAsync(string objectName, string recordId, object record);


### PR DESCRIPTION
Extended the API to allow specifying the expected body schema for an error response from a RestResource call. as per issue [issue #354](https://github.com/developerforce/Force.com-Toolkit-for-NET/issues/354).

Existing requests are all backwards compatible.