### PR TITLE
Remove web-server authentication flow example link

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,6 @@ After the user logs in you'll need to handle the callback and retrieve the code 
 await auth.WebServerAsync("YOURCONSUMERKEY", "YOURCONSUMERSECRET", "YOURCALLBACKURL", code);
 ```
 
-You can see a demonstration of this in the following sample application: https://github.com/developerforce/Force.com-Toolkit-for-NET/tree/master/samples/WebServerOAuthFlow
-
 #### Creating the ForceClient
 
 After this completes successfully you will receive a valid Access Token and Instance URL. The Instance URL returned identifies the web service URL you'll use to call the Force.com REST APIs, passing in the Access Token. Additionally, the authentication client will return the API version number, which is used to construct a valid HTTP request.


### PR DESCRIPTION
The link was removed because it returns a 404 and there doesn't appear to be a substitute.