### PR TITLE
Adding RunJobAndPollAsync  overload to IForceClient.cs

### DIFF
--- a/src/ForceToolkitForNET/IForceClient.cs
+++ b/src/ForceToolkitForNET/IForceClient.cs
@@ -42,6 +42,8 @@ namespace Salesforce.Force
         // BULK
         Task<List<BatchInfoResult>> RunJobAsync<T>(string objectName, BulkConstants.OperationType operationType, IEnumerable<ISObjectList<T>> recordsLists);
         Task<List<BatchResultList>> RunJobAndPollAsync<T>(string objectName, BulkConstants.OperationType operationType, IEnumerable<ISObjectList<T>> recordsLists);
+        Task<List<BatchResultList>> RunJobAndPollAsync<T>(string objectName, string externalIdFieldName, BulkConstants.OperationType operationType,
+            IEnumerable<ISObjectList<T>> recordsLists);
         Task<JobInfoResult> CreateJobAsync(string objectName, BulkConstants.OperationType operationType);
         Task<BatchInfoResult> CreateJobBatchAsync<T>(JobInfoResult jobInfo, ISObjectList<T> recordsObject);
         Task<BatchInfoResult> CreateJobBatchAsync<T>(string jobId, ISObjectList<T> recordsObject);


### PR DESCRIPTION
RunJobAndPollAsync is overloaded in ForceClient but not defined in IForceClient.cs