### PR TITLE
Pass request error status codes through to ForceException

### DIFF
--- a/src/CommonLibrariesForNET/AuthenticationClient.cs
+++ b/src/CommonLibrariesForNET/AuthenticationClient.cs
@@ -182,7 +182,7 @@ namespace Salesforce.Common
             else
             {
                 var errorResponse = JsonConvert.DeserializeObject<AuthErrorResponse>(response);
-                throw new ForceException(errorResponse.Error, errorResponse.ErrorDescription);
+                throw new ForceException(errorResponse.Error, errorResponse.ErrorDescription, responseMessage.StatusCode);
             }
         }
 
@@ -220,7 +220,7 @@ namespace Salesforce.Common
                 else
                 {
                     var errorResponse = JsonConvert.DeserializeObject<AuthErrorResponse>(response);
-                    throw new ForceException(errorResponse.Error, errorResponse.ErrorDescription);
+                    throw new ForceException(errorResponse.Error, errorResponse.ErrorDescription, responseMessage.StatusCode);
                 }
             }
             catch (Exception ex)

--- a/src/CommonLibrariesForNET/JsonHttpClient.cs
+++ b/src/CommonLibrariesForNET/JsonHttpClient.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
@@ -23,10 +24,10 @@ namespace Salesforce.Common
             HttpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
         }
 
-        private static ForceException ParseForceException(string responseMessage)
+        private static ForceException ParseForceException(string responseMessage, HttpStatusCode statusCode)
         {
             var errorResponse = JsonConvert.DeserializeObject<ErrorResponses>(responseMessage);
-            return new ForceException(errorResponse[0].ErrorCode, errorResponse[0].Message);
+            return new ForceException(errorResponse[0].ErrorCode, errorResponse[0].Message, statusCode);
         }
 
         // GET
@@ -61,7 +62,7 @@ namespace Salesforce.Common
             }
             catch (BaseHttpClientException e)
             {
-                throw ParseForceException(e.Message);
+                throw ParseForceException(e.Message, e.GetStatus());
             }
         }
 
@@ -87,7 +88,7 @@ namespace Salesforce.Common
                 }
                 catch (BaseHttpClientException e)
                 {
-                    throw ParseForceException(e.Message);
+                    throw ParseForceException(e.Message, e.GetStatus());
                 }
             }
             while (!string.IsNullOrEmpty(next));
@@ -150,7 +151,7 @@ namespace Salesforce.Common
             }
             catch (BaseHttpClientException e)
             {
-                throw ParseForceException(e.Message);
+                throw ParseForceException(e.Message, e.GetStatus());
             }
         }
 
@@ -193,7 +194,7 @@ namespace Salesforce.Common
                 return JsonConvert.DeserializeObject<T>(response);
             }
 
-            throw ParseForceException(response);
+            throw ParseForceException(response, responseMessage.StatusCode);
         }
 
         // PATCH
@@ -238,7 +239,7 @@ namespace Salesforce.Common
             }
             catch (BaseHttpClientException e)
             {
-                throw ParseForceException(e.Message);
+                throw ParseForceException(e.Message, e.GetStatus());
             }
         }
 
@@ -264,7 +265,7 @@ namespace Salesforce.Common
             }
             catch (BaseHttpClientException e)
             {
-                throw ParseForceException(e.Message);
+                throw ParseForceException(e.Message, e.GetStatus());
             }
         }
 
@@ -285,7 +286,7 @@ namespace Salesforce.Common
             }
             catch (BaseHttpClientException e)
             {
-                throw ParseForceException(e.Message);
+                throw ParseForceException(e.Message, e.GetStatus());
             }
         }
     }

--- a/src/CommonLibrariesForNET/XmlHttpClient.cs
+++ b/src/CommonLibrariesForNET/XmlHttpClient.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using System.Xml;
@@ -38,7 +39,7 @@ namespace Salesforce.Common
             }
             catch (BaseHttpClientException e)
             {
-                throw ParseForceException(e.Message);
+                throw ParseForceException(e.Message, e.GetStatus());
             }
         }
 
@@ -60,16 +61,16 @@ namespace Salesforce.Common
             }
             catch (BaseHttpClientException e)
             {
-                throw ParseForceException(e.Message);
+                throw ParseForceException(e.Message, e.GetStatus());
             }
         }
 
         // HELPER METHODS
 
-        private static ForceException ParseForceException(string responseMessage)
+        private static ForceException ParseForceException(string responseMessage, HttpStatusCode statusCode)
         {
             var errorResponse = DeserializeXmlString<ErrorResponse>(responseMessage);
-            return new ForceException(errorResponse.ErrorCode, errorResponse.Message);
+            return new ForceException(errorResponse.ErrorCode, errorResponse.Message, statusCode);
         }
 
         private static string SerializeXmlObject(object inputObject)


### PR DESCRIPTION
Looks like ForceException had a field for a status code but it was never being filled even though it was often being created due to non-success status codes.
This PR fixes that, so that any relevant status codes get passed back to the caller via ForceException whenever possible.