### PR TITLE
Expose signature and issued_at properties, and add revoke token method.

### DIFF
--- a/src/CommonLibrariesForNET/AuthenticationClient.cs
+++ b/src/CommonLibrariesForNET/AuthenticationClient.cs
@@ -16,6 +16,8 @@ namespace Salesforce.Common
         public string RefreshToken { get; set; }
         public string Id { get; set; }
         public string ApiVersion { get; set; }
+        public string Signature { get; set; }
+        public string IssuedAt { get; set; }
 
         private const string UserAgent = "forcedotcom-toolkit-dotnet";
         private const string TokenRequestEndpointUrl = "https://login.salesforce.com/services/oauth2/token";
@@ -78,6 +80,8 @@ namespace Salesforce.Common
                 AccessToken = authToken.AccessToken;
                 InstanceUrl = authToken.InstanceUrl;
                 Id = authToken.Id;
+                Signature = authToken.Signature;
+                IssuedAt = authToken.IssuedAt;
             }
             else
             {
@@ -130,6 +134,8 @@ namespace Salesforce.Common
                 InstanceUrl = authToken.InstanceUrl;
                 Id = authToken.Id;
                 RefreshToken = authToken.RefreshToken;
+                Signature = authToken.Signature;
+                IssuedAt = authToken.IssuedAt;
             }
             else
             {
@@ -178,6 +184,8 @@ namespace Salesforce.Common
                 RefreshToken = refreshToken;
                 InstanceUrl = authToken.InstanceUrl;
                 Id = authToken.Id;
+                Signature = authToken.Signature;
+                IssuedAt = authToken.IssuedAt;
             }
             else
             {

--- a/src/CommonLibrariesForNET/AuthenticationClient.cs
+++ b/src/CommonLibrariesForNET/AuthenticationClient.cs
@@ -194,6 +194,25 @@ namespace Salesforce.Common
             }
         }
 
+        public async Task TokenRevokeAsync()
+        {
+            HttpRequestMessage request = new HttpRequestMessage();
+            request.Method = HttpMethod.Post;
+            request.RequestUri = new Uri("https://login.salesforce.com/services/oauth2/revoke");
+            request.Content = new FormUrlEncodedContent(new[]
+            {
+                new KeyValuePair<string, string>("token", AccessToken)
+            });
+
+            try
+            {
+                HttpResponseMessage responseMessage = await _httpClient.SendAsync(request);
+            }
+            catch (Exception ex)
+            {
+                throw new ForceAuthException(Error.UnknownException, ex.Message);
+            }
+        }
 
         public async Task GetLatestVersionAsync()
         {


### PR DESCRIPTION
It would be useful if we could access `signature` and `issued_at` parameters after getting a token.

I also add a method to revoke current access token. Might solve issue #45.