### PR TITLE
Added support for UpdateAsync to push null values to Salesforce.

### DIFF
--- a/src/ForceToolkitForNET/ForceClient.cs
+++ b/src/ForceToolkitForNET/ForceClient.cs
@@ -155,6 +155,15 @@ namespace Salesforce.Force
             return _jsonHttpClient.HttpPatchAsync(record, string.Format("sobjects/{0}/{1}", objectName, recordId));
         }
 
+        public Task<SuccessResponse> UpdateAsync(string objectName, string recordId, object record, bool ignoreNull)
+        {
+            if (string.IsNullOrEmpty(objectName)) throw new ArgumentNullException("objectName");
+            if (string.IsNullOrEmpty(recordId)) throw new ArgumentNullException("recordId");
+            if (record == null) throw new ArgumentNullException("record");
+
+            return _jsonHttpClient.HttpPatchAsync(record, string.Format("sobjects/{0}/{1}", objectName, recordId), ignoreNull);
+        }
+
         public Task<SuccessResponse> UpsertExternalAsync(string objectName, string externalFieldName, string externalId, object record)
         {
             if (string.IsNullOrEmpty(objectName)) throw new ArgumentNullException("objectName");

--- a/src/ForceToolkitForNET/IForceClient.cs
+++ b/src/ForceToolkitForNET/IForceClient.cs
@@ -21,6 +21,7 @@ namespace Salesforce.Force
         Task<SuccessResponse> CreateAsync(string objectName, object record);
         Task<SaveResponse> CreateAsync(string objectName, CreateRequest request);
         Task<SuccessResponse> UpdateAsync(string objectName, string recordId, object record);
+        Task<SuccessResponse> UpdateAsync(string objectName, string recordId, object record, bool ignoreNull);
         Task<SuccessResponse> UpsertExternalAsync(string objectName, string externalFieldName, string externalId, object record);
         Task<SuccessResponse> UpsertExternalAsync(string objectName, string externalFieldName, string externalId, object record, bool ignoreNull);
         Task<bool> DeleteAsync(string objectName, string recordId);


### PR DESCRIPTION
This addresses portions of [pull request 268](https://github.com/wadewegner/Force.com-Toolkit-for-NET/pull/268) which were not implemented yet and also would resolve [issue 372](https://github.com/wadewegner/Force.com-Toolkit-for-NET/issues/372)