### PR TITLE
Feature/set max poll delay on job

### DIFF
--- a/src/ForceToolkitForNET/ForceClient.cs
+++ b/src/ForceToolkitForNET/ForceClient.cs
@@ -319,6 +319,7 @@ namespace Salesforce.Force
         {
             const float pollingStart = 1000;
             const float pollingIncrease = 2.0f;
+            const float maxPollDeplay = 20000;
 
             var batchInfoResults = await RunJobAsync(objectName, externalIdFieldName, operationType, recordsLists);
 
@@ -345,6 +346,7 @@ namespace Salesforce.Force
 
                 await Task.Delay((int)currentPoll);
                 currentPoll *= pollingIncrease;
+                if (currentPoll > maxPollDeplay) currentPoll = maxPollDeplay;
             }
 
 

--- a/src/ForceToolkitForNET/ForceClient.cs
+++ b/src/ForceToolkitForNET/ForceClient.cs
@@ -309,17 +309,16 @@ namespace Salesforce.Force
         }
 
         public async Task<List<BatchResultList>> RunJobAndPollAsync<T>(string objectName, BulkConstants.OperationType operationType,
-            IEnumerable<ISObjectList<T>> recordsLists)
+            IEnumerable<ISObjectList<T>> recordsLists, float? maxPollDelayMilliSeconds = null)
         {
-            return await RunJobAndPollAsync(objectName, null, operationType, recordsLists);
+            return await RunJobAndPollAsync(objectName, null, operationType, recordsLists, maxPollDelayMilliSeconds);
         }
 
         public async Task<List<BatchResultList>> RunJobAndPollAsync<T>(string objectName, string externalIdFieldName, BulkConstants.OperationType operationType,
-            IEnumerable<ISObjectList<T>> recordsLists)
+            IEnumerable<ISObjectList<T>> recordsLists, float? maxPollDelayMilliSeconds = null)
         {
             const float pollingStart = 1000;
             const float pollingIncrease = 2.0f;
-            const float maxPollDeplay = 20000;
 
             var batchInfoResults = await RunJobAsync(objectName, externalIdFieldName, operationType, recordsLists);
 
@@ -346,7 +345,7 @@ namespace Salesforce.Force
 
                 await Task.Delay((int)currentPoll);
                 currentPoll *= pollingIncrease;
-                if (currentPoll > maxPollDeplay) currentPoll = maxPollDeplay;
+                if (maxPollDelayMilliSeconds != null && currentPoll > maxPollDelayMilliSeconds) currentPoll = (float)maxPollDelayMilliSeconds;
             }
 
 

--- a/src/ForceToolkitForNET/IForceClient.cs
+++ b/src/ForceToolkitForNET/IForceClient.cs
@@ -41,7 +41,7 @@ namespace Salesforce.Force
 
         // BULK
         Task<List<BatchInfoResult>> RunJobAsync<T>(string objectName, BulkConstants.OperationType operationType, IEnumerable<ISObjectList<T>> recordsLists);
-        Task<List<BatchResultList>> RunJobAndPollAsync<T>(string objectName, BulkConstants.OperationType operationType, IEnumerable<ISObjectList<T>> recordsLists);
+        Task<List<BatchResultList>> RunJobAndPollAsync<T>(string objectName, BulkConstants.OperationType operationType, IEnumerable<ISObjectList<T>> recordsLists, float? maxPollDelayMilliSeconds = null);
         Task<JobInfoResult> CreateJobAsync(string objectName, BulkConstants.OperationType operationType);
         Task<BatchInfoResult> CreateJobBatchAsync<T>(JobInfoResult jobInfo, ISObjectList<T> recordsObject);
         Task<BatchInfoResult> CreateJobBatchAsync<T>(string jobId, ISObjectList<T> recordsObject);


### PR DESCRIPTION
Add the ability to set a custom max poll delay.

We are using the lib and experience that we sometimes wait quite as long time after SF finishes Job processing until the lib finished because it is awaiting to long to poll.
